### PR TITLE
Training: Assign page, reopen/close, workstation-only, analytics ($today)"

### DIFF
--- a/backend/src/__tests__/trainings.test.ts
+++ b/backend/src/__tests__/trainings.test.ts
@@ -1,0 +1,67 @@
+import request from 'supertest';
+import app from '../app';
+import * as db from '../db';
+
+jest.mock('../db');
+
+const mockPool: any = db;
+
+describe('Trainings routes', () => {
+  beforeAll(() => {
+    mockPool.pool = {
+      query: jest.fn().mockImplementation((q: string, vals?: any[]) => {
+        if (q.startsWith('INSERT INTO training_records')) {
+          const row: any = {
+            id: vals ? vals[0] : 't1',
+            employee_id: vals ? vals[1] : '1',
+            title: vals ? vals[2] : 'Test Training',
+            type: vals ? vals[3] : 'development',
+            status: vals ? vals[4] : 'not_started',
+            completion_date: vals ? vals[5] : null,
+            expiry_date: vals ? vals[6] : null,
+            provider: vals ? vals[7] : 'Provider',
+            created_at: new Date().toISOString(),
+            archived: false,
+          };
+          return Promise.resolve({ rows: [row], rowCount: 1 });
+        }
+        if (q.startsWith('SELECT * FROM training_records WHERE id')) {
+          return Promise.resolve({ rows: [{ id: vals ? vals[0] : 't1', employee_id: '1', title: 'A', status: 'not_started' }], rowCount: 1 });
+        }
+        if (q.startsWith('UPDATE training_records')) {
+          return Promise.resolve({ rows: [{ id: vals ? vals[vals.length-1] : 't1', status: 'completed' }], rowCount: 1 });
+        }
+        if (q.startsWith('DELETE FROM training_records')) {
+          return Promise.resolve({ rows: [], rowCount: 1 });
+        }
+        if (q.startsWith('SELECT * FROM training_records ORDER BY')) {
+          return Promise.resolve({ rows: [{ id: 't1', title: 'Seed' }], rowCount: 1 });
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      })
+    };
+  });
+
+  it('creates a training via POST /api/trainings', async () => {
+    const res = await request(app)
+      .post('/api/trainings')
+      .send({ employeeId: '1', title: 'New T', type: 'development', status: 'not_started', provider: 'X' });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id');
+    expect(res.body.title).toBeDefined();
+  });
+
+  it('updates a training via PUT /api/trainings/:id', async () => {
+    const res = await request(app)
+      .put('/api/trainings/t1')
+      .send({ status: 'completed' });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('completed');
+  });
+
+  it('deletes a training via DELETE /api/trainings/:id', async () => {
+    const res = await request(app)
+      .delete('/api/trainings/t1');
+    expect(res.status).toBe(204);
+  });
+});

--- a/backend/src/routes/trainings.ts
+++ b/backend/src/routes/trainings.ts
@@ -49,7 +49,7 @@ router.post('/', async (req: Request, res: Response) => {
       const upd: Record<string, any> = {};
       if (data.description !== undefined) upd.description = data.description;
       if (data.duration !== undefined) upd.duration = data.duration;
-      if (data.maxParticipants !== undefined) upd.max_participants = data.maxParticipants;
+      if (data.maxParticipants !== undefined || data.max_participants !== undefined) upd.max_participants = data.maxParticipants ?? data.max_participants;
       if (data.prerequisites !== undefined) upd.prerequisites = data.prerequisites;
       if (data.category !== undefined) upd.category = data.category;
       if (data.archived !== undefined) upd.archived = data.archived;

--- a/backend/src/routes/trainings.ts
+++ b/backend/src/routes/trainings.ts
@@ -13,12 +13,24 @@ router.get('/', async (_req: Request, res: Response) => {
   }
 });
 
+router.get('/:id', async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query('SELECT * FROM training_records WHERE id = $1 LIMIT 1', [id]);
+    if (result.rowCount === 0) return res.status(404).json({ error: 'Not found' });
+    res.json(result.rows[0]);
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});
+
 router.post('/', async (req: Request, res: Response) => {
   const data = req.body;
   const id = data.id || uuidv4();
   try {
-    const q = `INSERT INTO training_records(id, employee_id, title, type, status, completion_date, expiry_date, provider, archived, description, duration, max_participants, prerequisites, category, created_at) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING *`;
-    const vals = [
+    // Perform a minimal insert using core columns to avoid schema mismatch
+    const qMin = `INSERT INTO training_records(id, employee_id, title, type, status, completion_date, expiry_date, provider, created_at) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING *`;
+    const valsMin = [
       id,
       data.employeeId || null,
       data.title || null,
@@ -27,16 +39,92 @@ router.post('/', async (req: Request, res: Response) => {
       data.completionDate || null,
       data.expiryDate || null,
       data.provider || null,
-      data.archived || false,
-      data.description || null,
-      data.duration || null,
-      data.maxParticipants || data.max_participants || null,
-      data.prerequisites || null,
-      data.category || null,
       data.created_at || new Date().toISOString()
     ];
-    const result = await pool.query(q, vals);
-    res.status(201).json(result.rows[0]);
+    const resultMin = await pool.query(qMin, valsMin);
+    const created = resultMin.rows[0];
+
+    // Attempt to set optional extended fields (description, duration, archived, max_participants, prerequisites, category)
+    try {
+      const upd: Record<string, any> = {};
+      if (data.description !== undefined) upd.description = data.description;
+      if (data.duration !== undefined) upd.duration = data.duration;
+      if (data.maxParticipants !== undefined) upd.max_participants = data.maxParticipants;
+      if (data.prerequisites !== undefined) upd.prerequisites = data.prerequisites;
+      if (data.category !== undefined) upd.category = data.category;
+      if (data.archived !== undefined) upd.archived = data.archived;
+
+      const keys = Object.keys(upd);
+      if (keys.length > 0) {
+        const sets: string[] = [];
+        const vals: any[] = [];
+        let idx = 1;
+        for (const k of keys) {
+          sets.push(`${k} = $${idx}`);
+          vals.push((upd as any)[k]);
+          idx++;
+        }
+        vals.push(created.id);
+        const qUpd = `UPDATE training_records SET ${sets.join(', ')} WHERE id = $${idx} RETURNING *`;
+        const updRes = await pool.query(qUpd, vals);
+        return res.status(201).json(updRes.rows[0]);
+      }
+    } catch (ignore) {
+      // ignore errors updating optional fields (older schemas)
+    }
+
+    return res.status(201).json(created);
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+// Batch create trainings
+router.post('/batch', async (req: Request, res: Response) => {
+  const items = Array.isArray(req.body?.items) ? req.body.items : [];
+  if (items.length === 0) return res.status(400).json({ error: 'No items provided' });
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const created: any[] = [];
+    for (const raw of items) {
+      const {
+        employeeId,
+        title,
+        type,
+        provider,
+        status = 'not_started',
+        expiryDate,
+        completionDate,
+        description,
+        duration,
+        prerequisites,
+        category,
+        max_participants,
+      } = raw || {};
+      const q = `INSERT INTO training_records (employee_id, title, type, provider, status, expiry_date, completion_date, description, duration, prerequisites, category, max_participants)
+                 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+                 RETURNING *`;
+      const vals = [employeeId, title, type, provider, status, expiryDate ?? null, completionDate ?? null, description ?? null, duration ?? null, prerequisites ?? null, category ?? null, max_participants ?? null];
+      const result = await client.query(q, vals);
+      created.push(result.rows[0]);
+    }
+    await client.query('COMMIT');
+    res.json({ created });
+  } catch (err: any) {
+    await client.query('ROLLBACK');
+    res.status(500).json({ error: 'Failed to batch create trainings', details: err?.message });
+  } finally {
+    client.release();
+  }
+});
+
+router.delete('/:id', async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query('DELETE FROM training_records WHERE id = $1', [id]);
+    if (result.rowCount === 0) return res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
   } catch (err) {
     res.status(500).json({ error: String(err) });
   }
@@ -46,14 +134,20 @@ router.put('/:id', async (req: Request, res: Response) => {
   const { id } = req.params;
   const updates = req.body;
   try {
-    const keys = Object.keys(updates);
+    // normalize camelCase keys to snake_case to match DB column names
+    const normalized: Record<string, any> = {};
+    for (const k of Object.keys(updates)) {
+      const snake = k.replace(/([A-Z])/g, '_$1').toLowerCase();
+      normalized[snake] = (updates as any)[k];
+    }
+    const keys = Object.keys(normalized);
     if (keys.length === 0) return res.status(400).json({ error: 'no updates provided' });
     const sets: string[] = [];
     const vals: any[] = [];
     let idx = 1;
     for (const k of keys) {
       sets.push(`${k} = $${idx}`);
-      vals.push((updates as any)[k]);
+      vals.push((normalized as any)[k]);
       idx++;
     }
     vals.push(id);

--- a/database/generated/11-training-records-metadata.sql
+++ b/database/generated/11-training-records-metadata.sql
@@ -4,4 +4,5 @@ ALTER TABLE IF EXISTS training_records
   ADD COLUMN IF NOT EXISTS duration integer,
   ADD COLUMN IF NOT EXISTS max_participants integer,
   ADD COLUMN IF NOT EXISTS prerequisites text,
-  ADD COLUMN IF NOT EXISTS category text;
+  ADD COLUMN IF NOT EXISTS category text,
+  ADD COLUMN IF NOT EXISTS archived boolean DEFAULT false;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - db_data:/var/lib/postgresql/data
       - ./database/generated/mock-schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
       - ./database/generated/02-seed.sql:/docker-entrypoint-initdb.d/02-seed.sql:ro
+      - ./database/generated/mock-seed.sql:/docker-entrypoint-initdb.d/03-mock-seed.sql:ro
+      - ./database/generated/11-training-records-metadata.sql:/docker-entrypoint-initdb.d/11-training-records-metadata.sql:ro
       - ./database/generated/12-employees-status-retired.sql:/docker-entrypoint-initdb.d/12-employees-status-retired.sql:ro
       - ./database/generated/13-employees-kin-special-needs.sql:/docker-entrypoint-initdb.d/13-employees-kin-special-needs.sql:ro
       - ./database/generated/14-employees-home-subcounty.sql:/docker-entrypoint-initdb.d/14-employees-home-subcounty.sql:ro

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,8 @@ import { EmployeeDirectory } from "@/pages/EmployeeDirectory";
 import { EmployeeProfile } from "@/pages/EmployeeProfile";
 import Recruitment from "@/pages/Recruitment";
 import { Training } from "@/pages/Training";
+import TrainingProgramDetails from "@/pages/TrainingProgramDetails";
+import TrainingAssign from "@/pages/TrainingAssign";
 import { LeaveManagement } from "@/pages/LeaveManagement";
 import { PerformanceReviews } from "@/pages/PerformanceReviews";
 import { Reports } from "@/pages/Reports";
@@ -110,6 +112,8 @@ const App = () => (
                           <Route path="/profile" element={<ProtectedRoute><Layout><EmployeeProfile /></Layout></ProtectedRoute>} />
                           <Route path="/recruitment" element={<ProtectedRoute><Layout><Recruitment /></Layout></ProtectedRoute>} />
                           <Route path="/training" element={<ProtectedRoute><Layout><Training /></Layout></ProtectedRoute>} />
+                          <Route path="/training/program/:title" element={<ProtectedRoute><Layout><TrainingProgramDetails /></Layout></ProtectedRoute>} />
+                          <Route path="/training/assign/:title" element={<ProtectedRoute><Layout><TrainingAssign /></Layout></ProtectedRoute>} />
                           <Route path="/leave" element={<ProtectedRoute><Layout><LeaveManagement /></Layout></ProtectedRoute>} />
                           <Route path="/performance" element={<ProtectedRoute><Layout><PerformanceReviews /></Layout></ProtectedRoute>} />
                           <Route path="/performance/reviews/:id" element={<ProtectedRoute><Layout><PerformanceReviewDetails /></Layout></ProtectedRoute>} />

--- a/src/contexts/TrainingContext.tsx
+++ b/src/contexts/TrainingContext.tsx
@@ -6,33 +6,49 @@ import { useAuth } from '@/contexts/AuthContext';
 type TrainingContextType = {
   trainings: TrainingRecord[];
   createTraining: (payload: Partial<TrainingRecord>) => Promise<TrainingRecord | null>;
+  createTrainingsBatch: (items: Partial<TrainingRecord>[]) => Promise<TrainingRecord[]>;
   startTraining: (id: string) => void;
   completeTraining: (id: string, file?: File | null) => void;
   editTraining: (id: string, changes: Partial<TrainingRecord>) => Promise<TrainingRecord | null>;
   closeTraining: (id: string) => void;
   archiveTraining: (id: string) => void;
+  deleteTraining: (id: string) => Promise<boolean>;
   getCertificateUrl: (id: string) => string | undefined;
 };
-
-const STORAGE_KEY = 'hris-trainings';
 
 const TrainingContext = createContext<TrainingContextType | undefined>(undefined);
 
 export const TrainingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user } = useAuth();
-  const [trainings, setTrainings] = useState<TrainingRecord[]>(() => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) return JSON.parse(stored) as TrainingRecord[];
-    } catch {}
-    return [];
-  });
+  const [trainings, setTrainings] = useState<TrainingRecord[]>([]);
 
   const [certUrls, setCertUrls] = useState<Record<string, string>>({});
 
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(trainings));
-  }, [trainings]);
+  // Removed localStorage persistence to ensure DB is source of truth
+
+  // helper: backend row -> frontend model
+  const normalizeRow = (row: any): TrainingRecord => {
+    const rawStatus = row.status;
+    const allowed = ['not_started','in_progress','completed','closed'];
+    const status = allowed.includes(rawStatus) ? rawStatus : 'not_started';
+    const archived = (row.archived ?? false) || status === 'closed';
+    return {
+      id: row.id,
+      employeeId: row.employeeId ?? row.employee_id,
+      title: row.title,
+      type: row.type,
+      status,
+      description: row.description,
+      duration: row.duration,
+      max_participants: row.max_participants ?? row.maxParticipants,
+      prerequisites: row.prerequisites,
+      category: row.category,
+      completionDate: row.completionDate ?? row.completion_date,
+      expiryDate: row.expiryDate ?? row.expiry_date,
+      provider: row.provider,
+      archived,
+    };
+  };
 
   // load trainings from backend on mount
   useEffect(() => {
@@ -41,9 +57,10 @@ export const TrainingProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       try {
         const rows = await api.get('/api/trainings');
         if (!mounted) return;
-        if (Array.isArray(rows) && rows.length > 0) setTrainings(rows as TrainingRecord[]);
+        if (Array.isArray(rows) && rows.length > 0) setTrainings((rows as any[]).map(normalizeRow));
       } catch (err) {
-        // fallback to local
+        // no local fallback: keep current state and surface error in console for visibility
+        console.error('Failed to load trainings from API', err);
       }
     })();
     return () => { mounted = false; };
@@ -53,7 +70,7 @@ export const TrainingProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     (async () => {
       try {
         const updated = await api.put(`/api/trainings/${id}`, { status: 'in_progress' });
-        setTrainings(prev => prev.map(tr => tr.id === id ? (updated as TrainingRecord) : tr));
+        setTrainings(prev => prev.map(tr => tr.id === id ? normalizeRow(updated) : tr));
       } catch (err) {
         setTrainings(prev => prev.map(tr => tr.id === id ? { ...tr, status: 'in_progress' } as TrainingRecord : tr));
       }
@@ -62,24 +79,44 @@ export const TrainingProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
   const createTraining = async (payload: Partial<TrainingRecord>) => {
     try {
-      const created = await api.post('/api/trainings', payload);
-      setTrainings(prev => [created as TrainingRecord, ...prev]);
-      return created as TrainingRecord;
+      const body: any = { ...payload };
+      if (body.expiryDate) { body.expiry_date = body.expiryDate; delete body.expiryDate; }
+      if (body.completionDate) { body.completion_date = body.completionDate; delete body.completionDate; }
+      // normalize optional metadata to DB columns
+      if (Object.prototype.hasOwnProperty.call(body, 'maxParticipants')) {
+        body.max_participants = body.maxParticipants;
+        delete body.maxParticipants;
+      }
+      // keep description, duration, prerequisites, category, archived as-is (backend accepts these as provided)
+      const created = await api.post('/api/trainings', body);
+      const norm = normalizeRow(created);
+      setTrainings(prev => [norm, ...prev]);
+      return norm;
     } catch (err) {
-      // fallback: create a local entry
-      const local: TrainingRecord = {
-        id: crypto.randomUUID(),
-        employeeId: (payload.employeeId as string) || '0',
-        title: payload.title || 'Untitled',
-        type: (payload.type as any) || 'development',
-        status: (payload.status as any) || 'not_started',
-        completionDate: payload.completionDate,
-        expiryDate: payload.expiryDate,
-        provider: payload.provider,
-        archived: payload.archived || false
+      console.error('Failed to create training via API', err);
+      return null;
+    }
+  };
+
+  const createTrainingsBatch = async (items: Partial<TrainingRecord>[]) => {
+    try {
+      const body = {
+        items: items.map((p) => {
+          const o: any = { ...p };
+          if (o.expiryDate) { o.expiryDate = o.expiryDate; }
+          if (o.completionDate) { o.completionDate = o.completionDate; }
+          if (o.maxParticipants !== undefined) { o.max_participants = o.maxParticipants; delete o.maxParticipants; }
+          return o;
+        })
       };
-      setTrainings(prev => [local, ...prev]);
-      return local;
+      const resp = await api.post('/api/trainings/batch', body);
+      const created: any[] = Array.isArray(resp?.created) ? resp.created : [];
+      const norm = created.map(normalizeRow);
+      if (norm.length > 0) setTrainings(prev => [...norm, ...prev]);
+      return norm;
+    } catch (err) {
+      console.error('Failed to batch create trainings via API', err);
+      return [];
     }
   };
 
@@ -88,9 +125,9 @@ export const TrainingProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     (async () => {
       try {
         const updated = await api.put(`/api/trainings/${id}`, { status: 'completed', completion_date: completionDate });
-        setTrainings(prev => prev.map(tr => tr.id === id ? (updated as TrainingRecord) : tr));
+        setTrainings(prev => prev.map(tr => tr.id === id ? normalizeRow(updated) : tr));
       } catch (err) {
-        setTrainings(prev => prev.map(tr => tr.id === id ? { ...tr, status: 'completed', completionDate } as TrainingRecord : tr));
+        console.error('Failed to complete training via API', err);
       }
     })();
     if (file) {
@@ -101,11 +138,27 @@ export const TrainingProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
   const editTraining = async (id: string, changes: Partial<TrainingRecord>) => {
     try {
-      const updated = await api.put(`/api/trainings/${id}`, changes);
-      setTrainings(prev => prev.map(tr => tr.id === id ? (updated as TrainingRecord) : tr));
-      return updated as TrainingRecord;
+      // Map camelCase fields used in UI to snake_case columns expected by backend UPDATE
+      const payload: any = { ...changes };
+      if (Object.prototype.hasOwnProperty.call(payload, 'expiryDate')) {
+        payload.expiry_date = payload.expiryDate;
+        delete payload.expiryDate;
+      }
+      if (Object.prototype.hasOwnProperty.call(payload, 'completionDate')) {
+        payload.completion_date = payload.completionDate;
+        delete payload.completionDate;
+      }
+      // normalize maxParticipants to DB column name if provided in UI
+      if (Object.prototype.hasOwnProperty.call(payload, 'maxParticipants')) {
+        payload.max_participants = payload.maxParticipants;
+        delete payload.maxParticipants;
+      }
+      const updated = await api.put(`/api/trainings/${id}`, payload);
+      const norm = normalizeRow(updated);
+      setTrainings(prev => prev.map(tr => tr.id === id ? norm : tr));
+      return norm;
     } catch (err) {
-      setTrainings(prev => prev.map(tr => tr.id === id ? { ...tr, ...changes } : tr));
+      console.error('Failed to edit training via API', err);
       return null;
     }
   };
@@ -114,9 +167,9 @@ export const TrainingProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     (async () => {
       try {
         const updated = await api.put(`/api/trainings/${id}`, { status: 'closed' });
-        setTrainings(prev => prev.map(tr => tr.id === id ? (updated as TrainingRecord) : tr));
+        setTrainings(prev => prev.map(tr => tr.id === id ? normalizeRow(updated) : tr));
       } catch (err) {
-        setTrainings(prev => prev.map(tr => tr.id === id ? { ...tr, status: 'closed' } : tr));
+        console.error('Failed to close training via API', err);
       }
     })();
   };
@@ -125,16 +178,26 @@ export const TrainingProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     (async () => {
       try {
         const updated = await api.put(`/api/trainings/${id}`, { archived: true });
-        setTrainings(prev => prev.map(tr => tr.id === id ? (updated as TrainingRecord) : tr));
+        setTrainings(prev => prev.map(tr => tr.id === id ? normalizeRow(updated) : tr));
       } catch (err) {
-        setTrainings(prev => prev.map(tr => tr.id === id ? { ...tr, archived: true } : tr));
+        console.error('Failed to archive training via API', err);
       }
     })();
   };
 
+  const deleteTraining = async (id: string) => {
+    try {
+      await api.del(`/api/trainings/${id}`);
+      setTrainings(prev => prev.filter(tr => tr.id !== id));
+      return true;
+    } catch (err) {
+      return false;
+    }
+  };
+
   const getCertificateUrl = (id: string) => certUrls[id];
 
-  const value = useMemo(() => ({ trainings, createTraining, startTraining, completeTraining, editTraining, closeTraining, archiveTraining, getCertificateUrl }), [trainings, certUrls]);
+  const value = useMemo(() => ({ trainings, createTraining, createTrainingsBatch, startTraining, completeTraining, editTraining, closeTraining, archiveTraining, deleteTraining, getCertificateUrl }), [trainings, certUrls]);
 
   return (
     <TrainingContext.Provider value={value}>

--- a/src/pages/AdminTrainingManagement.tsx
+++ b/src/pages/AdminTrainingManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, BookOpen } from 'lucide-react';
 
@@ -12,6 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Badge } from '@/components/ui/badge';
 import { useSystemLogs } from '@/contexts/SystemLogsContext';
 import { useTraining } from '@/contexts/TrainingContext';
+import { useToast } from '@/hooks/use-toast';
 
 interface TrainingProgram {
   id: string;
@@ -31,12 +32,27 @@ interface TrainingProgram {
 export default function AdminTrainingManagement() {
   const navigate = useNavigate();
   const { addLog } = useSystemLogs();
+  const { toast } = useToast();
   
-  const { trainings: programs, createTraining } = useTraining();
+  const { trainings: trainingRows, createTraining } = useTraining();
   const { editTraining } = useTraining();
   const [isCreateProgramOpen, setIsCreateProgramOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
+  const [isViewOpen, setIsViewOpen] = useState(false);
   const [editingProgram, setEditingProgram] = useState<any | null>(null);
+  const [viewingProgram, setViewingProgram] = useState<any | null>(null);
+  // listing controls
+  const [q, setQ] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'open' | 'closed' | 'all'>('open');
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [page, setPage] = useState<number>(1);
+
+  // reset to first page when filters or size change or dataset refreshes
+  useEffect(() => { setPage(1); }, [q, statusFilter, pageSize, trainingRows]);
+
+  // simple inline validation state
+  const [createErrors, setCreateErrors] = useState<{ duration?: string; maxParticipants?: string }>({});
+  const [editErrors, setEditErrors] = useState<{ duration?: string; maxParticipants?: string }>({});
 
   const [newProgram, setNewProgram] = useState<Omit<TrainingProgram, 'id' | 'createdAt'>>({
     name: '',
@@ -48,13 +64,20 @@ export default function AdminTrainingManagement() {
   });
 
   const handleCreateProgram = () => {
+    // validate non-negative numbers
+    const newErr: typeof createErrors = {};
+    if (newProgram.duration < 0) newErr.duration = 'Duration must be non-negative';
+    if ((newProgram.maxParticipants ?? 0) < 0) newErr.maxParticipants = 'Max participants must be non-negative';
+    setCreateErrors(newErr);
+    if (Object.keys(newErr).length) return;
+
     if (newProgram.name && newProgram.description && newProgram.provider) {
       // create on server (or fallback to local if API unavailable)
       const payload = {
         employeeId: '0',
         title: newProgram.name,
         type: (newProgram.category === 'mandatory' ? 'mandatory' : newProgram.category === 'compliance' ? 'compliance' : 'development') as 'mandatory' | 'development' | 'compliance',
-        status: newProgram.status as 'active' | 'inactive',
+        status: 'not_started' as any,
         provider: newProgram.provider,
         description: newProgram.description,
         duration: newProgram.duration,
@@ -73,6 +96,7 @@ export default function AdminTrainingManagement() {
           entityId: program ? program.id : 'local',
           status: 'success'
         });
+        toast({ title: 'Program created', description: 'Training program saved successfully.' });
       });
       
       setNewProgram({
@@ -87,41 +111,78 @@ export default function AdminTrainingManagement() {
     }
   };
 
+  const toDateInput = (value: any) => {
+    if (!value) return '';
+    const s = String(value);
+    if (s.includes('T')) return s.split('T')[0];
+    return s;
+  };
+
   const openEdit = (program: any) => {
+    // program is an aggregated item; use its sampleId and titleKey to update all with same title
     setEditingProgram({
-      id: program.id,
+      id: program.sampleId || program.id,
       title: (program.title || program.name) || '',
+      titleKey: (program.title || program.name) || '',
       description: program.description || program.details || '',
       provider: program.provider || '',
       duration: program.duration || 1,
       maxParticipants: program.max_participants || program.maxParticipants || undefined,
       prerequisites: program.prerequisites || '',
       category: program.category || 'skill_development',
-      status: program.status || 'active'
+      type: program.type || (program.category === 'mandatory' ? 'mandatory' : program.category === 'compliance' ? 'compliance' : 'development'),
+      expiryDate: toDateInput(program.expiryDate || program.expiry_date || ''),
+      status: program.status || 'open'
     });
     setIsEditOpen(true);
   };
 
+  const openView = (program: any) => {
+    setViewingProgram({
+      ...program,
+      expiryDate: program.expiryDate || program.expiry_date || null
+    });
+    setIsViewOpen(true);
+  };
+
   const handleSaveEdit = () => {
     if (!editingProgram) return;
+    // validate
+    const errs: typeof editErrors = {};
+    if ((editingProgram.duration ?? 0) < 0) errs.duration = 'Duration must be non-negative';
+    if ((editingProgram.maxParticipants ?? 0) < 0) errs.maxParticipants = 'Max participants must be non-negative';
+    setEditErrors(errs);
+    if (Object.keys(errs).length) return;
     // call editTraining to persist changes
+  const normalizedStatus = (() => {
+    const s = (editingProgram.status || '').toString();
+    if (s === 'active' || s === 'not_started') return 'not_started';
+    if (s === 'inactive' || s === 'closed') return 'closed';
+    if (['in_progress','completed'].includes(s)) return s;
+    return 'not_started';
+  })();
   const editPayload = {
     title: editingProgram.title,
     provider: editingProgram.provider,
     description: editingProgram.description,
     duration: editingProgram.duration,
-    max_participants: editingProgram.maxParticipants,
+    maxParticipants: editingProgram.maxParticipants,
     prerequisites: editingProgram.prerequisites,
     category: editingProgram.category,
-    status: editingProgram.status
+    type: editingProgram.type,
+    expiryDate: editingProgram.expiryDate || undefined,
+    status: normalizedStatus
   } as Partial<any>;
 
-  editTraining(editingProgram.id || '', editPayload)
+  const applyToIds = (trainingRows || []).filter((row:any) => (row.title || '') === (editingProgram.titleKey || editingProgram.title)).map((r:any) => r.id);
+  const targets = applyToIds.length > 0 ? applyToIds : [editingProgram.id];
+
+  Promise.all(targets.map((id:string) => editTraining(id, editPayload)))
     .then(() => {
       addLog({
         action: 'Edited training program',
         actionType: 'update',
-        details: `Edited program: ${editingProgram.title}`,
+        details: `Edited program: ${editingProgram.title} (${targets.length} record${targets.length !== 1 ? 's' : ''})`,
         entityType: 'training_program',
         entityId: editingProgram.id,
         status: 'success'
@@ -129,9 +190,11 @@ export default function AdminTrainingManagement() {
 
       setIsEditOpen(false);
       setEditingProgram(null);
+      toast({ title: 'Program updated', description: 'Changes saved successfully.' });
     })
     .catch((err) => {
       console.error('Failed to save training edit', err);
+      toast({ title: 'Update failed', description: 'Could not save changes.', variant: 'destructive' });
     });
 
   };
@@ -148,8 +211,8 @@ export default function AdminTrainingManagement() {
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'active': return 'bg-green-100 text-green-800';
-      case 'inactive': return 'bg-gray-100 text-gray-800';
+      case 'open': return 'bg-green-100 text-green-800';
+      case 'closed': return 'bg-gray-100 text-gray-800';
       default: return 'bg-gray-100 text-gray-800';
     }
   };
@@ -303,9 +366,78 @@ export default function AdminTrainingManagement() {
                     <Label htmlFor="edit-provider">Provider</Label>
                     <Input id="edit-provider" value={editingProgram.provider} onChange={(e) => setEditingProgram((p:any) => ({ ...p, provider: e.target.value }))} />
                   </div>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-category">Category</Label>
+                      <Select value={editingProgram.category} onValueChange={(value:any) => setEditingProgram((p:any) => ({ ...p, category: value }))}>
+                        <SelectTrigger id="edit-category">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="mandatory">Mandatory</SelectItem>
+                          <SelectItem value="compliance">Compliance</SelectItem>
+                          <SelectItem value="skill_development">Skill Development</SelectItem>
+                          <SelectItem value="leadership">Leadership</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-type">Type</Label>
+                      <Select value={editingProgram.type} onValueChange={(value:any) => setEditingProgram((p:any) => ({ ...p, type: value }))}>
+                        <SelectTrigger id="edit-type">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="mandatory">mandatory</SelectItem>
+                          <SelectItem value="development">development</SelectItem>
+                          <SelectItem value="compliance">compliance</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-expiry">Expiry Date</Label>
+                      <Input id="edit-expiry" type="date" value={editingProgram.expiryDate || ''} onChange={(e) => setEditingProgram((p:any) => ({ ...p, expiryDate: e.target.value || '' }))} />
+                    </div>
+                  </div>
                   <div className="space-y-2">
                     <Label htmlFor="edit-desc">Description</Label>
                     <Textarea id="edit-desc" value={editingProgram.description} onChange={(e) => setEditingProgram((p:any) => ({ ...p, description: e.target.value }))} />
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-duration">Duration (hours)</Label>
+                      <Input id="edit-duration" type="number" value={String(editingProgram.duration ?? '')} onChange={(e) => {
+                        const v = e.target.value === '' ? undefined : parseInt(e.target.value);
+                        setEditingProgram((p:any) => ({ ...p, duration: v }));
+                        setEditErrors(prev => ({ ...prev, duration: v !== undefined && v < 0 ? 'Duration must be non-negative' : undefined }));
+                      }} />
+                      {editErrors.duration && <p className="text-xs text-destructive">{editErrors.duration}</p>}
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-max">Max Participants</Label>
+                      <Input id="edit-max" type="number" value={editingProgram.maxParticipants?.toString() || ''} onChange={(e) => {
+                        const v = e.target.value ? parseInt(e.target.value) : undefined;
+                        setEditingProgram((p:any) => ({ ...p, maxParticipants: v }));
+                        setEditErrors(prev => ({ ...prev, maxParticipants: v !== undefined && v < 0 ? 'Max participants must be non-negative' : undefined }));
+                      }} />
+                      {editErrors.maxParticipants && <p className="text-xs text-destructive">{editErrors.maxParticipants}</p>}
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-status">Status</Label>
+                      <Select value={editingProgram.status} onValueChange={(value:any) => setEditingProgram((p:any) => ({ ...p, status: value }))}>
+                        <SelectTrigger id="edit-status">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="active">Active</SelectItem>
+                          <SelectItem value="inactive">Inactive</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-prereq">Prerequisites</Label>
+                    <Textarea id="edit-prereq" value={editingProgram.prerequisites} onChange={(e) => setEditingProgram((p:any) => ({ ...p, prerequisites: e.target.value }))} />
                   </div>
                   <div className="flex justify-end gap-2">
                     <Button variant="outline" onClick={() => { setIsEditOpen(false); setEditingProgram(null); }}>Cancel</Button>
@@ -317,55 +449,184 @@ export default function AdminTrainingManagement() {
           </Dialog>
       </div>
 
-      <div className="grid gap-6">
-        {programs.map((program) => {
-          return (
-            <Card key={program.id}>
-              <CardHeader>
-                <div className="flex justify-between items-start">
-                  <div className="flex-1">
-                    <CardTitle className="flex items-center gap-2">
-                      <BookOpen className="w-5 h-5" />
-                      {(program as any).title || (program as any).name}
-                      <Badge className={getCategoryColor((program as any).category)}>
-                        {((program as any).category || '').replace('_', ' ')}
-                      </Badge>
-                      <Badge className={getStatusColor((program as any).status)}>
-                        {(program as any).status}
-                      </Badge>
-                    </CardTitle>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      {(program as any).description || (program as any).details || ''}
-                    </p>
-                  </div>
-                  <div className="ml-4 flex items-center gap-2">
-                    <Button size="sm" variant="ghost" onClick={() => openEdit(program)}>Edit</Button>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
-                    <div>
-                      <span className="font-medium">Duration:</span> {(program as any).duration ? `${(program as any).duration} hours` : 'N/A'}
-                    </div>
-                    <div>
-                      <span className="font-medium">Provider:</span> {(program as any).provider || 'N/A'}
-                    </div>
-                  </div>
+      {/* Aggregate records by program title to avoid duplicates, then filter and table-render */}
+      {(() => {
+        const progMap = new Map<string, any>();
+        (trainingRows || []).forEach((row: any) => {
+          const key = row.title || 'Untitled';
+          if (!progMap.has(key)) {
+            progMap.set(key, {
+              title: key,
+              name: key,
+              provider: row.provider || '',
+              category: row.category || 'skill_development',
+              type: row.type || (row.category === 'mandatory' ? 'mandatory' : row.category === 'compliance' ? 'compliance' : 'development'),
+              description: row.description || '',
+              duration: row.duration || undefined,
+              max_participants: row.max_participants || (row as any).maxParticipants,
+              prerequisites: row.prerequisites || '',
+              expiryDate: row.expiryDate || row.expiry_date || undefined,
+              sampleId: row.id,
+              counts: { total: 0, archived: 0, completed: 0 },
+            });
+          }
+          const p = progMap.get(key)!;
+          p.counts.total += 1;
+          if (row.archived) p.counts.archived += 1;
+          if (row.status === 'completed') p.counts.completed += 1;
+          const curExp = p.expiryDate ? new Date(p.expiryDate) : null;
+          const nextExp = row.expiryDate || row.expiry_date ? new Date(row.expiryDate || row.expiry_date) : null;
+          if ((!curExp && nextExp) || (curExp && nextExp && nextExp.getTime() < curExp.getTime())) p.expiryDate = (row.expiryDate || row.expiry_date);
+          if (!p.description && row.description) p.description = row.description;
+          if (!p.provider && row.provider) p.provider = row.provider;
+          if (!p.duration && row.duration) p.duration = row.duration;
+        });
+        const programList = Array.from(progMap.values()).map(p => ({
+          ...p,
+          status: p.counts.archived === p.counts.total ? 'closed' : 'open'
+        }));
+        const filtered = programList.filter((p:any) => {
+          const matchesQ = q ? (
+            (p.title || '').toLowerCase().includes(q.toLowerCase()) ||
+            (p.provider || '').toLowerCase().includes(q.toLowerCase())
+          ) : true;
+          const matchesStatus = statusFilter === 'all' ? true : p.status === statusFilter;
+          return matchesQ && matchesStatus;
+        });
+        return (
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <Input className="max-w-xs" placeholder="Search by name/provider" value={q} onChange={(e)=>setQ(e.target.value)} />
+              <Select value={statusFilter} onValueChange={(v:any)=>setStatusFilter(v)}>
+                <SelectTrigger className="w-40"><SelectValue placeholder="Status" /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="open">Open</SelectItem>
+                  <SelectItem value="closed">Closed</SelectItem>
+                  <SelectItem value="all">All</SelectItem>
+                </SelectContent>
+              </Select>
+              <div className="flex items-center gap-2 ml-auto">
+                <span className="text-xs text-muted-foreground">Rows per page</span>
+                <Select value={String(pageSize)} onValueChange={(v:any)=>setPageSize(Number(v))}>
+                  <SelectTrigger className="w-24"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="5">5</SelectItem>
+                    <SelectItem value="10">10</SelectItem>
+                    <SelectItem value="25">25</SelectItem>
+                    <SelectItem value="50">50</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
 
-                  {(program as any).prerequisites && (
-                    <div>
-                      <span className="font-medium text-sm">Prerequisites:</span>
-                      <p className="text-sm text-muted-foreground">{(program as any).prerequisites}</p>
-                    </div>
+            <div className="overflow-x-auto">
+              <table className="min-w-full table-auto border rounded">
+                <thead className="bg-muted/50">
+                  <tr className="text-left text-sm">
+                    <th className="p-2">Program</th>
+                    <th className="p-2">Category</th>
+                    <th className="p-2">Provider</th>
+                    <th className="p-2">Duration</th>
+                    <th className="p-2">Expiry</th>
+                    <th className="p-2">Enrolled</th>
+                    <th className="p-2">Completed</th>
+                    <th className="p-2">Status</th>
+                    <th className="p-2 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(() => {
+                    const total = filtered.length;
+                    const totalPages = Math.max(1, Math.ceil(total / pageSize));
+                    const safePage = Math.min(page, totalPages);
+                    const startIdx = (safePage - 1) * pageSize;
+                    const endIdx = Math.min(total, startIdx + pageSize);
+                    const paged = filtered.slice(startIdx, endIdx);
+                    return paged.map((program:any) => (
+                    <tr key={program.title} className="border-b last:border-0">
+                      <td className="p-2">
+                        <div className="flex items-center gap-2">
+                          <BookOpen className="w-4 h-4" />
+                          <div className="font-medium">{program.title}</div>
+                        </div>
+                      </td>
+                      <td className="p-2"><Badge className={getCategoryColor(program.category)}>{(program.category || '').replace('_',' ')}</Badge></td>
+                      <td className="p-2 text-sm">{program.provider || 'N/A'}</td>
+                      <td className="p-2 text-sm">{program.duration ? `${program.duration}h` : 'N/A'}</td>
+                      <td className="p-2 text-sm">{program.expiryDate ? new Date(program.expiryDate).toLocaleDateString() : 'N/A'}</td>
+                      <td className="p-2 text-sm">{program.counts?.total ?? 0}</td>
+                      <td className="p-2 text-sm">{program.counts?.completed ?? 0}</td>
+                      <td className="p-2"><Badge className={getStatusColor(program.status)}>{program.status}</Badge></td>
+                      <td className="p-2">
+                        <div className="flex justify-end gap-2">
+                          <Button size="sm" variant="outline" onClick={() => openView(program)}>View</Button>
+                          <Button size="sm" variant="ghost" onClick={() => openEdit(program)}>Edit</Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ));})()}
+                  {filtered.length === 0 && (
+                    <tr><td className="p-3 text-sm text-muted-foreground" colSpan={9}>No programs match your filters.</td></tr>
                   )}
+                </tbody>
+              </table>
+            </div>
+            {(() => {
+              const total = filtered.length;
+              if (total === 0) return null;
+              const totalPages = Math.max(1, Math.ceil(total / pageSize));
+              const safePage = Math.min(page, totalPages);
+              const start = (safePage - 1) * pageSize + 1;
+              const end = Math.min(total, safePage * pageSize);
+              return (
+                <div className="flex items-center justify-between mt-2 text-sm">
+                  <div className="text-muted-foreground">Showing {start}-{end} of {total}</div>
+                  <div className="flex items-center gap-2">
+                    <Button size="sm" variant="outline" disabled={safePage <= 1} onClick={() => setPage(p => Math.max(1, p - 1))}>Prev</Button>
+                    <span className="text-muted-foreground">Page {safePage} of {totalPages}</span>
+                    <Button size="sm" variant="outline" disabled={safePage >= totalPages} onClick={() => setPage(p => Math.min(totalPages, p + 1))}>Next</Button>
+                  </div>
                 </div>
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+              );
+            })()}
+          </div>
+        );
+      })()}
+
+      {/* View Program Dialog */}
+      <Dialog open={isViewOpen} onOpenChange={setIsViewOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Program Details</DialogTitle>
+          </DialogHeader>
+          {viewingProgram && (
+            <div className="space-y-3 text-sm">
+              <div className="grid grid-cols-2 gap-4">
+                <div><span className="font-medium">Title:</span> {(viewingProgram.title || viewingProgram.name)}</div>
+                <div><span className="font-medium">Provider:</span> {viewingProgram.provider || 'N/A'}</div>
+                <div><span className="font-medium">Type:</span> {viewingProgram.type || 'N/A'}</div>
+                <div><span className="font-medium">Category:</span> {(viewingProgram.category || '').toString().replace('_',' ') || 'N/A'}</div>
+                <div><span className="font-medium">Duration:</span> {viewingProgram.duration ? `${viewingProgram.duration} hours` : 'N/A'}</div>
+                <div><span className="font-medium">Max Participants:</span> {viewingProgram.max_participants ?? viewingProgram.maxParticipants ?? 'N/A'}</div>
+                <div><span className="font-medium">Status:</span> {viewingProgram.status || 'N/A'}</div>
+                <div><span className="font-medium">Expiry:</span> {viewingProgram.expiryDate ? new Date(viewingProgram.expiryDate).toLocaleDateString() : (viewingProgram.expiry_date ? new Date(viewingProgram.expiry_date).toLocaleDateString() : 'N/A')}</div>
+              </div>
+              {viewingProgram.prerequisites && (
+                <div>
+                  <span className="font-medium">Prerequisites:</span>
+                  <p className="text-muted-foreground">{viewingProgram.prerequisites}</p>
+                </div>
+              )}
+              {viewingProgram.description && (
+                <div>
+                  <span className="font-medium">Description:</span>
+                  <p className="text-muted-foreground">{viewingProgram.description}</p>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/ManagersOverview.tsx
+++ b/src/pages/ManagersOverview.tsx
@@ -109,7 +109,7 @@ const ManagersOverview: React.FC = () => {
     // Also include managers detected from employee records (position contains 'manager') that might not have a user
     const mgrFromEmployees = employees
       .filter(e => /manager/i.test(e.position || ''))
-      .map(e => ({ id: e.id, name: e.name, email: e.email, position: e.position, department: e.department, avatar: e.avatar }))
+      .map(e => ({ id: e.id, name: e.name, email: e.email, position: e.position, stationName: getWorkStation(e as any), avatar: e.avatar }))
 
     // Combine by unique name/email/id (prefer users)
     const combined: any[] = []
@@ -119,7 +119,7 @@ const ManagersOverview: React.FC = () => {
       const key = u.email || u.id || u.name
       if (!seen.has(key)) {
         seen.add(key)
-        combined.push({ id: u.id, name: u.name || u.email, email: u.email, position: 'Manager', department: 'Unassigned', avatar: u.avatar })
+  combined.push({ id: u.id, name: u.name || u.email, email: u.email, position: 'Manager', stationName: 'Unassigned', avatar: u.avatar })
       }
     })
 
@@ -127,7 +127,7 @@ const ManagersOverview: React.FC = () => {
       const key = e.email || e.id || e.name
       if (!seen.has(key)) {
         seen.add(key)
-        combined.push({ id: e.id, name: e.name, email: e.email, position: e.position, department: e.department, avatar: e.avatar })
+  combined.push({ id: e.id, name: e.name, email: e.email, position: e.position, stationName: getWorkStation(e as any), avatar: e.avatar })
       }
     })
 
@@ -187,18 +187,18 @@ const ManagersOverview: React.FC = () => {
     navigate('/employees')
   }
 
-  // Filter managers/employees by search query (search name, email, position, department)
+  // Filter managers/employees by search query (search name, email, position, workstation)
   const matchesQuery = (item: any, q: string) => {
     if (!q) return true
     const s = q.toLowerCase()
-    return (item.name || '').toLowerCase().includes(s) || (item.email || '').toLowerCase().includes(s) || (item.position || '').toLowerCase().includes(s) || (item.department || '').toLowerCase().includes(s)
+    return (item.name || '').toLowerCase().includes(s) || (item.email || '').toLowerCase().includes(s) || (item.position || '').toLowerCase().includes(s) || (getWorkStation(item as any) || '').toLowerCase().includes(s)
   }
 
   return (
     <div className="space-y-6">
         <div>
           <h1 className="text-3xl font-bold">Managers Overview</h1>
-          <p className="text-muted-foreground">View all managers, their department/workstation and direct reports.</p>
+          <p className="text-muted-foreground">View all managers, their workstation and direct reports.</p>
         </div>
 
         <div className="flex items-center gap-3">

--- a/src/pages/PerformanceReviews.tsx
+++ b/src/pages/PerformanceReviews.tsx
@@ -149,11 +149,11 @@ export const PerformanceReviews: React.FC = () => {
   // HR Assign: multi-employee selection and deadline
   const [selectedEmployees, setSelectedEmployees] = useState<string[]>([]);
   const [deadlineDate, setDeadlineDate] = useState('');
-  // HR Assign: department selection to auto-select employees
+  // HR Assign: workstation selection to auto-select employees
   const departments = useMemo(() => Array.from(new Set(employees.map(e => getWorkStation(e)))), [employees]);
   const [assignDepartment, setAssignDepartment] = useState<string>('all');
   const employeesByDept = useMemo(() => assignDepartment === 'all' ? employees : employees.filter(e => getWorkStation(e) === assignDepartment), [employees, assignDepartment]);
-  // Filter templates by department for assignment; allow global (no department) templates when a department is chosen
+  // Filter templates by station for assignment; allow global (no department) templates when a station is chosen
   const filteredTemplates = useMemo(() => {
     if (assignDepartment === 'all') return templates;
     return templates.filter(t => !t.department || t.department === assignDepartment);
@@ -164,11 +164,11 @@ export const PerformanceReviews: React.FC = () => {
     return !!(selectedTemplate.department && selectedTemplate.department !== assignDepartment);
   }, [assignDepartment, selectedTemplate]);
   useEffect(() => {
-    // when department changes, auto-select all employees in that department
+    // when workstation changes, auto-select all employees in that station
     if (assignDepartment === 'all') {
       setSelectedEmployees([]);
     } else {
-      setSelectedEmployees(employees.filter(e => e.department === assignDepartment).map(e => e.id));
+      setSelectedEmployees(employees.filter(e => getWorkStation(e) === assignDepartment).map(e => e.id));
     }
   }, [assignDepartment, employees]);
 
@@ -706,10 +706,10 @@ const handleSubmitToManager = () => {
                       <label className="text-sm font-medium">Department</label>
                       <Select value={assignDepartment} onValueChange={setAssignDepartment}>
                         <SelectTrigger>
-                          <SelectValue placeholder="All Departments" />
+                          <SelectValue placeholder="All Workstations" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="all">All Departments</SelectItem>
+                          <SelectItem value="all">All Workstations</SelectItem>
                           {departments.map((dept) => (
                             <SelectItem key={dept} value={dept}>{dept}</SelectItem>
                           ))}
@@ -749,7 +749,7 @@ const handleSubmitToManager = () => {
                           />
                           <div className="min-w-0">
                             <p className="text-sm font-medium truncate">{emp.name}</p>
-                            <p className="text-xs text-muted-foreground truncate">{emp.position} • {emp.department}</p>
+                            <p className="text-xs text-muted-foreground truncate">{emp.position} • {getWorkStation(emp)}</p>
                           </div>
                         </div>
                       ))}
@@ -799,7 +799,7 @@ const handleSubmitToManager = () => {
                           <div>
                             <h4 className="font-medium">{review.employeeName}</h4>
                             <p className="text-sm text-muted-foreground">{review.reviewPeriod} • {template?.name}</p>
-                            <p className="text-sm text-muted-foreground">Department: {employee?.department}</p>
+                            <p className="text-sm text-muted-foreground">Workstation: {getWorkStation(employee)}</p>
                             <p className="text-sm text-muted-foreground">Employee No: {(employee as any)?.employeeNumber || '-'}</p>
                             {review.deadlineDate && (
                               <p className="text-sm text-muted-foreground">Deadline: {new Date(review.deadlineDate).toLocaleDateString()}</p>
@@ -951,7 +951,7 @@ const handleSubmitToManager = () => {
                               {review.employeeName}
                             </CardTitle>
                             <CardDescription>
-                              {review.reviewPeriod} • {template?.name} • {employee?.department}
+                              {review.reviewPeriod} • {template?.name} • {getWorkStation(employee)}
                             </CardDescription>
                           </div>
                           <Badge variant="outline" className="bg-yellow-50 text-yellow-700 border-yellow-200">
@@ -1027,7 +1027,7 @@ const handleSubmitToManager = () => {
                                     <div>
                                       <p className="font-medium">Employee: {review.employeeName}</p>
                                       <p className="text-sm text-muted-foreground">Period: {review.reviewPeriod}</p>
-                                      <p className="text-sm text-muted-foreground">Department: {employee?.department}</p>
+                                      <p className="text-sm text-muted-foreground">Workstation: {getWorkStation(employee)}</p>
                                     </div>
                                     <div>
                                       <p className="font-medium">Template: {template?.name}</p>

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -313,7 +313,7 @@ export const Reports: React.FC = () => {
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <Card className="lg:col-span-2">
               <CardHeader>
-                <CardTitle className="flex items-center gap-2"><PieChart className="w-4 h-4" /> Department Distribution</CardTitle>
+                <CardTitle className="flex items-center gap-2"><PieChart className="w-4 h-4" /> Workstation Distribution</CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="space-y-2">
@@ -389,7 +389,7 @@ export const Reports: React.FC = () => {
             </Card>
             <Card>
               <CardHeader>
-                <CardTitle>Largest Departments</CardTitle>
+                <CardTitle>Largest Workstations</CardTitle>
               </CardHeader>
               <CardContent className="space-y-2">
                 {Object.entries(workforce.byDept)
@@ -456,7 +456,7 @@ export const Reports: React.FC = () => {
               <div className="text-sm text-muted-foreground">Total: {retirementsUpcoming.length}</div>
               {retirementsUpcoming.slice(0,10).map(r => (
                 <div key={r.id} className="flex justify-between text-sm">
-                  <span className="truncate max-w-[60%]" title={`${r.name} • ${r.department} • ${r.cadre || ''}`}>{r.name}</span>
+                  <span className="truncate max-w-[60%]" title={`${r.name} • ${r.stationName || r.department} • ${r.cadre || ''}`}>{r.name}</span>
                   <span className="text-muted-foreground">{new Date(r.retirement).toLocaleDateString()}</span>
                 </div>
               ))}

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -88,7 +88,7 @@ export const Training: React.FC = () => {
       return {
         id: r.id,
         employeeName: emp?.name || `Employee ${r.employeeId}`,
-        department: emp?.department || emp?.stationName,
+        department: emp?.stationName,
         status: r.status,
         completionDate: r.completionDate,
       };
@@ -617,7 +617,7 @@ export const Training: React.FC = () => {
                           <h4 className="font-medium">{training.title}</h4>
                           {['hr_manager', 'hr_staff'].includes(user?.role || '') && (
                             <p className="text-sm text-muted-foreground">
-                              {employee?.name} • {employee?.department}
+                              {employee?.name} • {employee?.stationName}
                             </p>
                           )}
                           <p className="text-xs text-muted-foreground">

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -580,7 +580,7 @@ export const Training: React.FC = () => {
                           <p className="text-xs text-muted-foreground">Archived assignments: {related.length} • Completed: {completed}</p>
                         </div>
                         <div className="flex gap-2">
-                          <Button size="sm" variant="outline" onClick={() => (window.location.href = `/training/program/${encodeURIComponent(title)}`)}>View</Button>
+                          <Button size="sm" variant="outline" onClick={() => navigate(`/training/program/${encodeURIComponent(title)}`)}>View</Button>
                           <Button size="sm" onClick={async () => {
                             const related = trainings.filter(t => (t.title || 'Untitled') === title && t.archived);
                             await Promise.all(related.map(r => editTraining(r.id, { archived: false, ...(r.status === 'closed' ? { status: 'not_started' as any } : {}) })));

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import { Plus, Search, Filter, GraduationCap, Clock, CheckCircle, Calendar, Upload, Users } from 'lucide-react';
+import { Plus, Search, Filter, GraduationCap, Clock, CheckCircle, Calendar, Upload, Users, Eye, Pencil, Lock, BarChart } from 'lucide-react';
+import TrainingProgress from '@/pages/TrainingProgress';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -11,28 +12,36 @@ import { useEmployees } from '@/contexts/EmployeesContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { mapRole } from '@/lib/roles';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Checkbox } from '@/components/ui/checkbox';
 import { useTraining } from '@/contexts/TrainingContext';
+import { useToast } from '@/hooks/use-toast';
+import { useNavigate } from 'react-router-dom';
 
 export const Training: React.FC = () => {
   const { user } = useAuth();
-  const { trainings, startTraining, completeTraining, createTraining, editTraining, closeTraining, archiveTraining } = useTraining();
-  const [isAssigning, setIsAssigning] = useState(false);
-  const [activeTab, setActiveTab] = useState('overview');
+  const { trainings, startTraining, completeTraining, createTraining, editTraining, closeTraining, archiveTraining, deleteTraining } = useTraining();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState('dashboard');
   const [searchQuery, setSearchQuery] = useState('');
   const [completeOpen, setCompleteOpen] = useState(false);
   const [selectedTrainingId, setSelectedTrainingId] = useState<string | null>(null);
   const [certificateFile, setCertificateFile] = useState<File | null>(null);
-  const [assignDialogOpen, setAssignDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [closeConfirmOpen, setCloseConfirmOpen] = useState(false);
-  const [selectedProgram, setSelectedProgram] = useState<any>(null);
-  const [selectedEmployees, setSelectedEmployees] = useState<string[]>([]);
+  const [viewDialogOpen, setViewDialogOpen] = useState(false);
+  const [viewProgram, setViewProgram] = useState<any | null>(null);
+  const [closeAllDialogOpen, setCloseAllDialogOpen] = useState(false);
+  const [programToCloseAll, setProgramToCloseAll] = useState<any | null>(null);
   // Edit form state
   const [editTitle, setEditTitle] = useState('');
   const [editProvider, setEditProvider] = useState('');
   const [editExpiryDate, setEditExpiryDate] = useState<string | undefined>(undefined);
   const [editType, setEditType] = useState<'mandatory' | 'development' | 'compliance'>('development');
+  const [editDescription, setEditDescription] = useState('');
+  const [editDuration, setEditDuration] = useState<number | ''>('');
+  const [editMaxParticipants, setEditMaxParticipants] = useState<number | ''>('');
+  const [editPrerequisites, setEditPrerequisites] = useState('');
+  const [editCategory, setEditCategory] = useState<'mandatory' | 'skill_development' | 'compliance' | 'leadership' | ''>('');
 
   // Source of truth for training records (context)
   const source = useMemo(() => trainings, [trainings]);
@@ -42,17 +51,20 @@ export const Training: React.FC = () => {
   const filteredRecords = useMemo(() => {
     if (!user) return [] as typeof trainings;
     const canonical = mapRole(user.role);
-    if (canonical === 'employee' || canonical === 'manager') {
-      return source.filter(tr => tr.employeeId === user.id);
+    if (canonical === 'hr') return source; // HR can audit all (including closed/archived for history)
+    if (canonical === 'employee' || canonical === 'manager' || canonical === 'registry') {
+      // Employees/managers/registry should NOT see closed or archived assignments on their dashboard
+      return source.filter(tr => tr.employeeId === user.id && !tr.archived && tr.status !== 'closed');
     }
-    // HR and admins see all records by default
-    return source;
+    // Admin/unknown: no records view
+    return [] as typeof trainings;
   }, [user, source]);
 
   // Trainings that belong to the currently logged-in user (used for 'My Trainings')
   const myTrainings = useMemo(() => {
     if (!user) return [] as typeof trainings;
-    return source.filter(tr => tr.employeeId === user.id);
+    // Hide closed/archived records from the employee's own list
+    return source.filter(tr => tr.employeeId === user.id && !tr.archived && tr.status !== 'closed');
   }, [user, source]);
 
   const completedTrainings = filteredRecords.filter(tr => tr.status === 'completed');
@@ -60,31 +72,61 @@ export const Training: React.FC = () => {
   const notStartedTrainings = filteredRecords.filter(tr => tr.status === 'not_started');
   const closedTrainings = filteredRecords.filter(tr => tr.status === 'closed');
   const archivedTrainings = trainings.filter(tr => tr.archived);
+  const archivedProgramTitles = useMemo(() => {
+    const s = new Set<string>();
+    archivedTrainings.forEach(tr => s.add(tr.title || 'Untitled'));
+    return Array.from(s.values()).sort((a,b) => a.localeCompare(b));
+  }, [archivedTrainings]);
 
-  // Function to handle employee assignment and persist training records
-  const handleAssignTraining = async () => {
-    if (!selectedProgram || selectedEmployees.length === 0) return;
-    setIsAssigning(true);
-    try {
-      for (const employeeId of selectedEmployees) {
-        // TrainingContext#createTraining will try the API and fall back to local storage.
-        await createTraining({
-          employeeId,
-          title: selectedProgram.title,
-          type: selectedProgram.type,
-          provider: selectedProgram.provider,
-          status: 'not_started'
-        });
-      }
-    } catch (err) {
-      console.error('Error assigning trainings', err);
-    } finally {
-      setIsAssigning(false);
-      setAssignDialogOpen(false);
-      setSelectedProgram(null);
-      setSelectedEmployees([]);
-    }
+  const [historyViewOpen, setHistoryViewOpen] = useState(false);
+  const [historyView, setHistoryView] = useState<null | { title: string; items: Array<{ id: string; employeeName: string; department?: string; status: string; completionDate?: string }>; completed: number; total: number }>(null);
+
+  const openHistoryView = (title: string) => {
+    const related = archivedTrainings.filter(t => (t.title || 'Untitled') === title);
+    const items = related.map(r => {
+      const emp = (employees || []).find(e => e.id === r.employeeId);
+      return {
+        id: r.id,
+        employeeName: emp?.name || `Employee ${r.employeeId}`,
+        department: emp?.department || emp?.stationName,
+        status: r.status,
+        completionDate: r.completionDate,
+      };
+    }).sort((a,b) => a.employeeName.localeCompare(b.employeeName));
+    setHistoryView({
+      title,
+      items,
+      completed: related.filter(r => r.status === 'completed').length,
+      total: related.length,
+    });
+    setHistoryViewOpen(true);
   };
+
+  // Date helpers and compliance-like metrics
+  const now = useMemo(() => new Date(), []);
+  const isWithinDays = (dateStr?: string, days?: number) => {
+    if (!dateStr || !days) return false;
+    const dt = new Date(dateStr);
+    if (isNaN(dt.getTime())) return false;
+    const diff = dt.getTime() - now.getTime();
+    return diff >= 0 && diff <= days * 24 * 60 * 60 * 1000;
+  };
+  const scopeForExpiry = useMemo(() => (mapRole(user?.role) === 'hr' ? source : filteredRecords), [user, source, filteredRecords]);
+  const expiringSoonRecords = scopeForExpiry.filter(tr => !!tr.expiryDate && isWithinDays(tr.expiryDate, 30));
+  const overdueRecords = scopeForExpiry.filter(tr => !!tr.expiryDate && new Date(tr.expiryDate).getTime() < now.getTime() && tr.status !== 'completed');
+
+  const typeBreakdown = useMemo(() => {
+    return scopeForExpiry.reduce(
+      (acc, tr) => {
+        const key = tr.type || 'development';
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+  }, [scopeForExpiry]);
+
+  // Assignment moved to dedicated page (/training/assign/:title)
 
   // Admin actions: edit and close
   useEffect(() => {
@@ -95,41 +137,53 @@ export const Training: React.FC = () => {
         setEditProvider(tr.provider || '');
         setEditExpiryDate(tr.expiryDate);
         setEditType(tr.type || 'development');
+        setEditDescription(tr.description || '');
+        setEditDuration(tr.duration ?? '');
+        // support both legacy and normalized naming
+        setEditMaxParticipants((tr as any).maxParticipants ?? (tr as any).max_participants ?? '');
+        setEditPrerequisites(tr.prerequisites || '');
+        setEditCategory((tr.category as any) || '');
       }
     }
   }, [editDialogOpen, selectedTrainingId, trainings]);
 
   const handleSaveEdit = () => {
     if (!selectedTrainingId) return;
-    editTraining(selectedTrainingId, { title: editTitle, provider: editProvider, expiryDate: editExpiryDate, type: editType });
+    const payload: any = { title: editTitle, provider: editProvider, expiryDate: editExpiryDate, type: editType };
+    // Admin can edit all fields; HR is not allowed to change advanced metadata per requirement
+    const canEditAll = canonical === 'admin';
+    if (canEditAll) {
+      payload.description = editDescription || undefined;
+      payload.duration = editDuration === '' ? undefined : Number(editDuration);
+      payload.maxParticipants = editMaxParticipants === '' ? undefined : Number(editMaxParticipants);
+      payload.prerequisites = editPrerequisites || undefined;
+      payload.category = editCategory || undefined;
+    }
+    editTraining(selectedTrainingId, payload);
     setEditDialogOpen(false);
     setSelectedTrainingId(null);
+    toast({ title: 'Training updated', description: 'Changes saved.' });
   };
 
   const handleConfirmClose = () => {
     if (!selectedTrainingId) return;
-    closeTraining(selectedTrainingId);
+    // Close means hide from assignees while preserving progress: mark as archived
+    archiveTraining(selectedTrainingId);
     setCloseConfirmOpen(false);
     setSelectedTrainingId(null);
+    setActiveTab('history');
+    toast({ title: 'Training closed', description: 'Hidden from assignees. You can reopen from History.' });
   };
 
   const { employees } = useEmployees();
-  const handleSelectAllEmployees = (checked: boolean) => {
-    if (checked) {
-      const allEmployeeIds = (employees || [])
-        .filter(emp => !/hr_(manager|staff)/i.test(String(emp.position || '').toLowerCase()))
-        .map(emp => emp.id);
-      setSelectedEmployees(allEmployeeIds);
-    } else {
-      setSelectedEmployees([]);
-    }
-  };
 
   // Derive available training programs from backend training records.
   // Collapse records by title and use the first matching record as a template for program metadata.
   const trainingPrograms = useMemo(() => {
+    // Consider any title that has at least one non-archived record as OPEN program
+    const active = trainings.filter(tr => !tr.archived);
     const map = new Map<string, any>();
-    trainings.forEach(tr => {
+    active.forEach(tr => {
       const key = tr.title || 'Untitled';
       if (!map.has(key)) {
         map.set(key, {
@@ -151,40 +205,100 @@ export const Training: React.FC = () => {
     return Array.from(map.values());
   }, [trainings]);
 
-  // Mock compliance dashboard
-  const complianceData = [
-    {
-      requirement: 'Cybersecurity Training',
-      totalEmployees: (employees || []).length,
-      compliant: 12,
-      expiringSoon: 2,
-      overdue: 1
-    },
-    {
-      requirement: 'Data Protection Training',
-      totalEmployees: (employees || []).length,
-      compliant: 18,
-      expiringSoon: 0,
-      overdue: 0
-    },
-    {
-      requirement: 'Health & Safety Training',
-      totalEmployees: (employees || []).length,
-      compliant: 15,
-      expiringSoon: 3,
-      overdue: 2
-    }
-  ];
+  const openViewProgram = (program: any) => {
+    // Aggregate details from records with same title
+    const related = trainings.filter(tr => tr.title === program.title);
+    const earliestExpiry = related
+      .map(tr => tr.expiryDate)
+      .filter(Boolean)
+      .map(d => new Date(d as string))
+      .sort((a,b) => a.getTime() - b.getTime())[0];
+    const sample = related.find(tr => tr.description || tr.prerequisites || tr.category || (tr as any).duration);
+    setViewProgram({
+      title: program.title,
+      provider: program.provider,
+      type: program.type,
+      category: sample?.category,
+      description: program.description || sample?.description,
+      duration: program.duration || (sample as any)?.duration,
+      maxParticipants: (sample as any)?.maxParticipants ?? (sample as any)?.max_participants,
+      prerequisites: sample?.prerequisites,
+      expiryDate: earliestExpiry ? earliestExpiry.toISOString() : undefined,
+      enrolled: related.length,
+      completed: related.filter(r => r.status === 'completed').length
+    });
+    setViewDialogOpen(true);
+  };
 
+  // Derive a simple per-program progress (HR-only usage in overview)
+  const programProgress = useMemo(() => {
+    const map = new Map<string, { title: string; enrolled: number; completed: number }>();
+    scopeForExpiry.forEach(tr => {
+      const key = tr.title || 'Untitled';
+      if (!map.has(key)) map.set(key, { title: key, enrolled: 0, completed: 0 });
+      const item = map.get(key)!;
+      item.enrolled += 1;
+      if (tr.status === 'completed') item.completed += 1;
+    });
+    return Array.from(map.values()).sort((a,b) => b.enrolled - a.enrolled).slice(0,5);
+  }, [scopeForExpiry]);
+
+  const canonical = mapRole(user?.role);
+
+  // Admin quick-create form state (set timelines at creation)
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newProvider, setNewProvider] = useState('');
+  const [newType, setNewType] = useState<'mandatory' | 'development' | 'compliance'>('development');
+  const [newExpiryDate, setNewExpiryDate] = useState<string | undefined>(undefined);
+  const [newDescription, setNewDescription] = useState('');
+  const [newDuration, setNewDuration] = useState<number | ''>('');
+  const [newMaxParticipants, setNewMaxParticipants] = useState<number | ''>('');
+  const [newPrerequisites, setNewPrerequisites] = useState('');
+  const [newCategory, setNewCategory] = useState<'mandatory' | 'skill_development' | 'compliance' | 'leadership' | ''>('');
+
+  const handleCreateProgram = async () => {
+    try {
+      // Admin creates a seed program by creating a record for themselves (or a neutral holder)
+      const seedEmployeeId = user?.id || '0';
+      await createTraining({
+        employeeId: seedEmployeeId,
+        title: newTitle,
+        type: newType,
+        provider: newProvider,
+        expiryDate: newExpiryDate,
+        description: newDescription || undefined,
+        duration: newDuration === '' ? undefined : Number(newDuration),
+        // backend uses max_participants; TrainingContext normalizes when editing; for create we send camel and context maps snake when present
+        max_participants: undefined as any,
+        prerequisites: newPrerequisites || undefined,
+        category: newCategory || undefined,
+        status: 'not_started'
+      } as any);
+      setCreateOpen(false);
+      setNewTitle(''); setNewProvider(''); setNewType('development'); setNewExpiryDate(undefined);
+      setNewDescription(''); setNewDuration(''); setNewMaxParticipants(''); setNewPrerequisites(''); setNewCategory('');
+      toast({ title: 'Program created', description: 'Timelines captured at creation.' });
+    } catch (e) {
+      toast({ title: 'Create failed', description: 'Could not create program.', variant: 'destructive' });
+    }
+  };
+
+  // navigation via useNavigate
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-start">
         <div>
           <h1 className="text-3xl font-bold mb-2">Training & CPD</h1>
           <p className="text-muted-foreground">
-            {(user?.role === 'employee' || user?.role === 'manager') ? 'Your assigned trainings and completions' : 'Manage training programs and compliance'}
+            {['employee','manager','registry'].includes(canonical) ? 'Your assigned trainings and completions' : 'Manage training programs and compliance'}
           </p>
         </div>
+        {canonical === 'admin' && (
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="w-4 h-4 mr-2" /> New Program
+          </Button>
+        )}
       </div>
 
       {/* Overview Stats */}
@@ -238,132 +352,137 @@ export const Training: React.FC = () => {
                 <Calendar className="w-6 h-6 text-destructive" />
               </div>
               <div>
-                <p className="text-sm font-medium text-muted-foreground">Expiring Soon</p>
-                <p className="text-2xl font-bold">5</p>
+                <p className="text-sm font-medium text-muted-foreground">Expiring Soon (30d)</p>
+                <p className="text-2xl font-bold">{expiringSoonRecords.length}</p>
               </div>
             </div>
           </CardContent>
         </Card>
       </div>
 
-      {/* Main Content Tabs */}
+      {/* Main Content Tabs (restored chip style, with Progress Dashboard as a tab) */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="grid w-full grid-cols-4">
-            {mapRole(user?.role) === 'hr' ? (
-                  <>
-                    <TabsTrigger
-                      value="overview"
-                      className="bg-blue-600 text-white data-[state=active]:bg-blue-800 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow"
-                    >
-                      Overview
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="assignments"
-                      className="bg-gray-200 text-gray-800 data-[state=active]:bg-green-500 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow"
-                    >
-                      Training Assignments
-                    </TabsTrigger>
-                                        <TabsTrigger
-                      value="my-trainings"
-                      className="bg-gray-200 text-gray-800 data-[state=active]:bg-green-500 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow"
-                    >
-                      My Trainings
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="history"
-                      className="bg-gray-200 text-gray-800 data-[state=active]:bg-slate-700 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow"
-                    >
-                      History
-                    </TabsTrigger>
-                  </>
-                ) : (
-              <>
-                <TabsTrigger
-                  value="overview"
-                  className="bg-blue-600 text-white data-[state=active]:bg-blue-800 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow"
-                >
-                  Overview
-                </TabsTrigger>
-                <TabsTrigger
-                  value="records"
-                  className="bg-gray-200 text-gray-800 data-[state=active]:bg-green-500 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow"
-                >
-                  {(user?.role === 'employee' || user?.role === 'manager') ? 'My Trainings' : 'Employee Trainings'}
-                </TabsTrigger>
-              </>
-            )}
-          </TabsList>
+  <TabsList className={`grid w-full ${canonical === 'hr' ? 'grid-cols-4' : (canonical === 'admin' ? 'grid-cols-1' : 'grid-cols-2')}`}>
+          {/* Progress Dashboard tab */}
+          <TabsTrigger
+            value="dashboard"
+            className="bg-blue-600 text-white data-[state=active]:bg-blue-800 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow flex items-center gap-2"
+          >
+            <BarChart className="w-4 h-4" /> Progress Dashboard
+          </TabsTrigger>
+          {/* HR extras: assignments, my trainings, history */}
+          {canonical === 'hr' && (
+            <>
+              <TabsTrigger
+                value="assignments"
+                className="bg-gray-200 text-gray-800 data-[state=active]:bg-green-500 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow flex items-center gap-2"
+              >
+                <Users className="w-4 h-4" /> Training Assignments
+              </TabsTrigger>
+              <TabsTrigger
+                value="my-trainings"
+                className="bg-gray-200 text-gray-800 data-[state=active]:bg-green-500 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow"
+              >
+                My Trainings
+              </TabsTrigger>
+              <TabsTrigger
+                value="history"
+                className="bg-gray-200 text-gray-800 data-[state=active]:bg-slate-700 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow"
+              >
+                History
+              </TabsTrigger>
+            </>
+          )}
+          {/* Non-admin, non-HR: can see their own 'My Trainings' */}
+          {canonical !== 'hr' && canonical !== 'admin' && (
+            <TabsTrigger
+              value="my-trainings"
+              className="bg-gray-200 text-gray-800 data-[state=active]:bg-green-500 data-[state=active]:text-white rounded-lg py-2 text-lg font-semibold shadow"
+            >
+              My Trainings
+            </TabsTrigger>
+          )}
+        </TabsList>
 
-        {/* Overview */}
-  <TabsContent value="overview">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Recent Training Activity</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  {filteredRecords.slice(0, 5).map((training) => {
-                    const employee = (employees || []).find(emp => emp.id === training.employeeId);
-                    return (
-                      <div key={training.id} className="flex items-center justify-between p-3 bg-muted/30 rounded-lg">
-                        <div className="flex items-center gap-3">
-                          <div className="bg-primary/10 p-2 rounded">
-                            <GraduationCap className="w-4 h-4 text-primary" />
-                          </div>
-                          <div>
-                            <p className="font-medium text-sm">{training.title}</p>
-                            <p className="text-xs text-muted-foreground">
-                              {employee?.name} • {training.provider}
-                            </p>
-                          </div>
-                        </div>
-                        <Badge className={`status-${training.status === 'completed' ? 'approved' : training.status === 'in_progress' ? 'pending' : 'draft'}`}>
-                          {training.status.replace('_', ' ')}
-                        </Badge>
-                        {['hr_manager', 'hr_staff'].includes(user?.role || '') && (
-                          <div className="ml-3 flex items-center gap-2">
-                            <Button size="sm" variant="ghost" onClick={() => { setSelectedTrainingId(training.id); setEditDialogOpen(true); }}>
-                              Edit
-                            </Button>
-                            {training.status !== 'closed' && (
-                              <Button size="sm" variant="outline" onClick={() => { setSelectedTrainingId(training.id); setCloseConfirmOpen(true); }}>
-                                Close
+        {/* Dashboard Tab */}
+        <TabsContent value="dashboard">
+          {canonical === 'hr' ? (
+            <div className="mt-4"><TrainingProgress /></div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Your Pending Trainings</CardTitle>
+                  <CardDescription>Quick actions for your assignments</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {filteredRecords
+                    .filter(tr => tr.status !== 'completed' && !tr.archived && tr.status !== 'closed')
+                    .slice(0,5)
+                    .map(training => (
+                    <div key={training.id} className="flex items-center justify-between p-3 border rounded-lg">
+                      <div>
+                        <p className="font-medium text-sm">{training.title}</p>
+                        <p className="text-xs text-muted-foreground">{training.provider}{training.expiryDate ? ` • Expires ${new Date(training.expiryDate).toLocaleDateString()}` : ''}</p>
+                      </div>
+                      <div className="flex gap-2">
+                        {training.status === 'not_started' && (
+                          <Button size="sm" variant="outline" onClick={() => startTraining(training.id)}>Start</Button>
+                        )}
+                        {(training.status === 'in_progress' || training.status === 'not_started') && (
+                          <Dialog open={completeOpen && selectedTrainingId === training.id} onOpenChange={(o) => { setCompleteOpen(o); if (!o) { setSelectedTrainingId(null); setCertificateFile(null); } }}>
+                            <DialogTrigger asChild>
+                              <Button size="sm" onClick={() => { setCompleteOpen(true); setSelectedTrainingId(training.id); }}>
+                                <Upload className="w-4 h-4 mr-2" />
+                                Complete & Upload Certificate
                               </Button>
-                            )}
-                            {training.status === 'closed' && (
-                              <Button size="sm" variant="destructive" onClick={() => archiveTraining(training.id)}>
-                                Archive
-                              </Button>
-                            )}
-                          </div>
+                            </DialogTrigger>
+                            <DialogContent>
+                              <DialogHeader>
+                                <DialogTitle>Upload Completion Certificate</DialogTitle>
+                                <DialogDescription>Attach your certificate to mark training as complete.</DialogDescription>
+                              </DialogHeader>
+                              <div className="space-y-2">
+                                <Input type="file" onChange={(e)=> setCertificateFile(e.target.files && e.target.files[0] ? e.target.files[0] : null)} />
+                              </div>
+                              <DialogFooter>
+                                <Button onClick={() => { completeTraining(training.id, certificateFile); setCompleteOpen(false); setSelectedTrainingId(null); setCertificateFile(null); }}>Submit</Button>
+                              </DialogFooter>
+                            </DialogContent>
+                          </Dialog>
                         )}
                       </div>
-                    );
-                  })}
-                </div>
-              </CardContent>
-            </Card>
-          </div>
+                    </div>
+                  ))}
+                  {filteredRecords.filter(tr => tr.status !== 'completed' && !tr.archived && tr.status !== 'closed').length === 0 && (
+                    <p className="text-sm text-muted-foreground">You're all caught up.</p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          )}
         </TabsContent>
 
         {/* HR: Training Assignments Tab */}
-        {['hr_manager', 'hr_staff'].includes(user?.role || '') && (
+        {canonical === 'hr' && (
           <TabsContent value="assignments">
             <Card>
               <CardHeader>
-                <CardTitle>Training Assignments</CardTitle>
-                <CardDescription>Assign training programs to employees and track completion status</CardDescription>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <CardTitle>Training Assignments</CardTitle>
+                    <CardDescription>Assign training programs to employees and track completion status</CardDescription>
+                  </div>
+                  {/* Progress Dashboard button removed */}
+                </div>
               </CardHeader>
               <CardContent>
                 <div className="space-y-6">
-                  {/* Training Programs with Employee Status */}
                   {trainingPrograms.map((program) => {
-                    const enrolledEmployees = filteredRecords.filter(tr => tr.title === program.title);
+                    const enrolledEmployees = trainings.filter(tr => tr.title === program.title && !tr.archived);
                     const completedCount = enrolledEmployees.filter(tr => tr.status === 'completed').length;
                     const inProgressCount = enrolledEmployees.filter(tr => tr.status === 'in_progress').length;
                     const notStartedCount = enrolledEmployees.filter(tr => tr.status === 'not_started').length;
-                    
                     return (
                       <div key={program.id} className="border rounded-lg p-4">
                         <div className="flex justify-between items-start mb-4">
@@ -378,25 +497,29 @@ export const Training: React.FC = () => {
                               <Badge variant="outline">{program.provider}</Badge>
                             </div>
                           </div>
-                          <Button 
-                            size="sm"
-                            onClick={() => {
-                              setSelectedProgram(program);
-                              setAssignDialogOpen(true);
-                            }}
-                          >
-                            <Plus className="w-4 h-4 mr-2" />
-                            Assign to Employees
-                          </Button>
+                          <div className="flex flex-wrap gap-2">
+                            <Button size="sm" variant="outline" onClick={() => openViewProgram(program)}>
+                              <Eye className="w-4 h-4 mr-1" /> View
+                            </Button>
+                            <Button size="sm" variant="ghost" onClick={() => {
+                              const first = trainings.find(t => t.title === program.title);
+                              if (first) { setSelectedTrainingId(first.id); setEditDialogOpen(true); }
+                            }}>
+                              <Pencil className="w-4 h-4 mr-1" /> Edit
+                            </Button>
+                            <Button size="sm" onClick={() => navigate(`/training/assign/${encodeURIComponent(program.title)}`)}>
+                              <Plus className="w-4 h-4 mr-1" /> Assign
+                            </Button>
+                            <Button size="sm" variant="secondary" onClick={() => { setProgramToCloseAll(program); setCloseAllDialogOpen(true); }}>
+                              <Lock className="w-4 h-4 mr-1" /> Close All
+                            </Button>
+                          </div>
                         </div>
-                        
                         <div className="grid grid-cols-3 gap-4">
                           <Card>
                             <CardContent className="p-4">
                               <div className="flex items-center gap-3">
-                                <div className="bg-success/10 p-2 rounded">
-                                  <CheckCircle className="w-5 h-5 text-success" />
-                                </div>
+                                <div className="bg-success/10 p-2 rounded"><CheckCircle className="w-5 h-5 text-success" /></div>
                                 <div>
                                   <p className="text-sm font-medium text-muted-foreground">Completed</p>
                                   <p className="text-xl font-bold">{completedCount}</p>
@@ -404,13 +527,10 @@ export const Training: React.FC = () => {
                               </div>
                             </CardContent>
                           </Card>
-                          
                           <Card>
                             <CardContent className="p-4">
                               <div className="flex items-center gap-3">
-                                <div className="bg-warning/10 p-2 rounded">
-                                  <Clock className="w-5 h-5 text-warning" />
-                                </div>
+                                <div className="bg-warning/10 p-2 rounded"><Clock className="w-5 h-5 text-warning" /></div>
                                 <div>
                                   <p className="text-sm font-medium text-muted-foreground">In Progress</p>
                                   <p className="text-xl font-bold">{inProgressCount}</p>
@@ -418,13 +538,10 @@ export const Training: React.FC = () => {
                               </div>
                             </CardContent>
                           </Card>
-                          
                           <Card>
                             <CardContent className="p-4">
                               <div className="flex items-center gap-3">
-                                <div className="bg-muted/50 p-2 rounded">
-                                  <GraduationCap className="w-5 h-5 text-muted-foreground" />
-                                </div>
+                                <div className="bg-muted/50 p-2 rounded"><GraduationCap className="w-5 h-5 text-muted-foreground" /></div>
                                 <div>
                                   <p className="text-sm font-medium text-muted-foreground">Not Started</p>
                                   <p className="text-xl font-bold">{notStartedCount}</p>
@@ -441,37 +558,46 @@ export const Training: React.FC = () => {
             </Card>
           </TabsContent>
         )}
-        {['hr_manager', 'hr_staff'].includes(user?.role || '') && (
+        {canonical === 'hr' && (
           <TabsContent value="history">
             <Card>
               <CardHeader>
                 <CardTitle>Training History</CardTitle>
-                <CardDescription>Archived trainings and past records</CardDescription>
+                <CardDescription>Closed trainings by program (you can reopen)</CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="space-y-3">
-                  {archivedTrainings.length === 0 && <p className="text-sm text-muted-foreground">No archived trainings</p>}
-                  {archivedTrainings.map(tr => (
-                    <div key={tr.id} className="flex items-center justify-between p-3 border rounded-lg">
-                      <div>
-                        <p className="font-medium">{tr.title}</p>
-                        <p className="text-xs text-muted-foreground">Provider: {tr.provider} • Status: {tr.status}</p>
-                      </div>
-                      <div className="text-right">
-                        {tr.completionDate && <p className="text-xs">Completed: {new Date(tr.completionDate).toLocaleDateString()}</p>}
-                        <div className="mt-2 flex gap-2 justify-end">
-                          <Button size="sm" variant="ghost" onClick={() => { setSelectedTrainingId(tr.id); setEditDialogOpen(true); }}>Edit</Button>
-                          <Button size="sm" onClick={() => editTraining(tr.id, { archived: false })}>Restore</Button>
+                  {archivedProgramTitles.length === 0 && (
+                    <p className="text-sm text-muted-foreground">No archived trainings</p>
+                  )}
+                  {archivedProgramTitles.map(title => {
+                    const related = archivedTrainings.filter(t => (t.title || 'Untitled') === title);
+                    const completed = related.filter(r => r.status === 'completed').length;
+                    return (
+                      <div key={title} className="flex items-center justify-between p-3 border rounded-lg">
+                        <div>
+                          <p className="font-medium">{title}</p>
+                          <p className="text-xs text-muted-foreground">Archived assignments: {related.length} • Completed: {completed}</p>
+                        </div>
+                        <div className="flex gap-2">
+                          <Button size="sm" variant="outline" onClick={() => (window.location.href = `/training/program/${encodeURIComponent(title)}`)}>View</Button>
+                          <Button size="sm" onClick={async () => {
+                            const related = trainings.filter(t => (t.title || 'Untitled') === title && t.archived);
+                            await Promise.all(related.map(r => editTraining(r.id, { archived: false, ...(r.status === 'closed' ? { status: 'not_started' as any } : {}) })));
+                            toast({ title: 'Reopened', description: `Reopened ${related.length} assignment(s) for ${title}.` });
+                            setActiveTab('assignments');
+                          }}>Reopen</Button>
                         </div>
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </CardContent>
             </Card>
           </TabsContent>
         )}
-  {/* Employee/Manager Records tab (reused by non-HR users) */}
+  {/* Legacy Records tab is replaced by My Trainings for non-HR */}
+  {/* Keeping content block for compatibility if needed (no trigger shown) */}
   <TabsContent value="records">
           <Card>
             <CardHeader>
@@ -520,7 +646,7 @@ export const Training: React.FC = () => {
                             {training.status === 'closed' && <Button size="sm" variant="destructive" onClick={() => archiveTraining(training.id)}>Archive</Button>}
                           </div>
                         )}
-                        {(user?.role === 'employee' || user?.role === 'manager') && training.status !== 'completed' && (
+                        {(['employee','manager','registry'].includes(canonical)) && training.status !== 'completed' && (
                           <div className="flex justify-end gap-2 mt-2">
                             {training.status === 'not_started' && (
                               <Button size="sm" variant="outline" onClick={() => startTraining(training.id)}>Start Training</Button>
@@ -558,8 +684,8 @@ export const Training: React.FC = () => {
           </Card>
         </TabsContent>
 
-        {/* HR: My Trainings tab - shows trainings assigned to the logged-in HR user so they can complete them using the same flow */}
-        <TabsContent value="my-trainings">
+  {/* My Trainings tab - shown for HR and all non-admin users */}
+  <TabsContent value="my-trainings">
           <Card>
             <CardHeader>
               <CardTitle>My Training Records</CardTitle>
@@ -589,7 +715,7 @@ export const Training: React.FC = () => {
                         {training.expiryDate && (
                           <p className="text-xs text-muted-foreground">Expires: {new Date(training.expiryDate).toLocaleDateString()}</p>
                         )}
-                        {(user?.role === 'employee' || user?.role === 'manager' || ['hr_manager', 'hr_staff'].includes(user?.role || '')) && training.status !== 'completed' && (
+                        {(['employee','manager','registry','hr'].includes(canonical)) && training.status !== 'completed' && (
                           <div className="flex justify-end gap-2 mt-2">
                             {training.status === 'not_started' && (
                               <Button size="sm" variant="outline" onClick={() => startTraining(training.id)}>Start Training</Button>
@@ -627,100 +753,21 @@ export const Training: React.FC = () => {
           </Card>
         </TabsContent>
 
-        {/* Remove Compliance tab for simplified employee view */}
+        {/* Remove Compliance tab for simplified view */}
       </Tabs>
 
-      {/* Assignment Dialog */}
-      <Dialog open={assignDialogOpen} onOpenChange={setAssignDialogOpen}>
-        <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Assign Training Program</DialogTitle>
-            <DialogDescription>
-              Assign "{selectedProgram?.title}" to employees
-            </DialogDescription>
-          </DialogHeader>
-          
-          {selectedProgram && (
-            <div className="space-y-4">
-              <div className="bg-muted/30 p-4 rounded-lg">
-                <h4 className="font-medium">{selectedProgram.title}</h4>
-                <p className="text-sm text-muted-foreground">{selectedProgram.description}</p>
-                <div className="flex gap-2 mt-2">
-                  <Badge variant={selectedProgram.type === 'mandatory' ? 'destructive' : 'secondary'}>
-                    {selectedProgram.type}
-                  </Badge>
-                  <Badge variant="outline">{selectedProgram.duration}</Badge>
-                  <Badge variant="outline">{selectedProgram.provider}</Badge>
-                </div>
-              </div>
-
-              <div>
-                <div className="flex items-center justify-between mb-4">
-                  <h4 className="font-medium">Select Employees</h4>
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                                          checked={selectedEmployees.length === (employees || []).filter(emp => !/hr_(manager|staff)/i.test(String(emp.position || '').toLowerCase())).length}
-                                          onCheckedChange={handleSelectAllEmployees}
-                                        />
-                                        <label className="text-sm font-medium">Select All</label>
-                  </div>
-                </div>
-                
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 max-h-60 overflow-y-auto">
-                  {(employees || [])
-                                      .filter(emp => !/hr_(manager|staff)/i.test(String(emp.position || '').toLowerCase()))
-                                      .map((employee) => (
-                                      <div key={employee.id} className="flex items-center space-x-3 p-3 border rounded-lg">
-                                        <Checkbox
-                                          checked={selectedEmployees.includes(employee.id)}
-                                          onCheckedChange={(checked) => {
-                                            if (checked) {
-                                              setSelectedEmployees(prev => [...prev, employee.id]);
-                                            } else {
-                                              setSelectedEmployees(prev => prev.filter(id => id !== employee.id));
-                                            }
-                                          }}
-                                        />
-                                        <div className="flex-1 min-w-0">
-                                          <p className="text-sm font-medium truncate">{employee.name}</p>
-                                          <p className="text-xs text-muted-foreground truncate">{employee.position} • {employee.stationName || employee.department}</p>
-                                        </div>
-                                      </div>
-                                    ))}
-                </div>
-              </div>
-              
-              <div className="bg-blue-50 p-3 rounded-lg">
-                <div className="flex items-center gap-2">
-                  <Users className="w-4 h-4 text-blue-600" />
-                  <span className="text-sm font-medium text-blue-600">
-                    {selectedEmployees.length} employee{selectedEmployees.length !== 1 ? 's' : ''} selected
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
-          
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setAssignDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button 
-              onClick={handleAssignTraining}
-              disabled={selectedEmployees.length === 0 || isAssigning}
-            >
-              {isAssigning ? 'Assigning...' : `Assign Training to ${selectedEmployees.length} Employee${selectedEmployees.length !== 1 ? 's' : ''}`}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {/* Assignment Dialog removed: use dedicated /training/assign/:title page */}
 
       {/* Edit Training Dialog */}
       <Dialog open={editDialogOpen} onOpenChange={(o) => { setEditDialogOpen(o); if (!o) { setSelectedTrainingId(null); } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Edit Training</DialogTitle>
-            <DialogDescription>Modify training title, provider, type or expiry date.</DialogDescription>
+            <DialogDescription>
+              {canonical === 'admin'
+                ? 'Admins can modify all program fields including timelines, description, duration, max participants and prerequisites.'
+                : 'HR can adjust basic details if needed; primary actions are assignment and closing.'}
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-3">
             <label className="text-sm font-medium">Title</label>
@@ -736,10 +783,96 @@ export const Training: React.FC = () => {
               </select>
               <Input type="date" value={editExpiryDate || ''} onChange={(e) => setEditExpiryDate(e.target.value || undefined)} />
             </div>
+            {canonical === 'admin' && (
+              <>
+                <label className="text-sm font-medium">Description</label>
+                <Input value={editDescription} onChange={(e) => setEditDescription(e.target.value)} placeholder="Short description" />
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+                  <div>
+                    <label className="text-sm font-medium">Duration (hours)</label>
+                    <Input type="number" value={editDuration} onChange={(e) => setEditDuration(e.target.value === '' ? '' : Number(e.target.value))} placeholder="e.g. 4" />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">Max Participants</label>
+                    <Input type="number" value={editMaxParticipants} onChange={(e) => setEditMaxParticipants(e.target.value === '' ? '' : Number(e.target.value))} placeholder="e.g. 25" />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">Category</label>
+                    <select value={editCategory} onChange={(e) => setEditCategory(e.target.value as any)} className="p-2 border rounded w-full">
+                      <option value="">--</option>
+                      <option value="mandatory">mandatory</option>
+                      <option value="skill_development">skill_development</option>
+                      <option value="compliance">compliance</option>
+                      <option value="leadership">leadership</option>
+                    </select>
+                  </div>
+                </div>
+                <label className="text-sm font-medium">Prerequisites</label>
+                <Input value={editPrerequisites} onChange={(e) => setEditPrerequisites(e.target.value)} placeholder="List prerequisites" />
+              </>
+            )}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => { setEditDialogOpen(false); setSelectedTrainingId(null); }}>Cancel</Button>
             <Button onClick={handleSaveEdit}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Admin Create Program Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Training Program</DialogTitle>
+            <DialogDescription>Admins set timelines at creation; HR will only assign and close.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <label className="text-sm font-medium">Title</label>
+            <Input value={newTitle} onChange={(e) => setNewTitle(e.target.value)} placeholder="Title" />
+            <label className="text-sm font-medium">Provider</label>
+            <Input value={newProvider} onChange={(e) => setNewProvider(e.target.value)} placeholder="Provider" />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              <div>
+                <label className="text-sm font-medium">Type</label>
+                <select value={newType} onChange={(e) => setNewType(e.target.value as any)} className="p-2 border rounded w-full">
+                  <option value="mandatory">mandatory</option>
+                  <option value="development">development</option>
+                  <option value="compliance">compliance</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium">Expiry Date</label>
+                <Input type="date" value={newExpiryDate || ''} onChange={(e) => setNewExpiryDate(e.target.value || undefined)} />
+              </div>
+            </div>
+            <label className="text-sm font-medium">Description</label>
+            <Input value={newDescription} onChange={(e) => setNewDescription(e.target.value)} placeholder="Short description" />
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+              <div>
+                <label className="text-sm font-medium">Duration (hours)</label>
+                <Input type="number" value={newDuration} onChange={(e) => setNewDuration(e.target.value === '' ? '' : Number(e.target.value))} />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Max Participants</label>
+                <Input type="number" value={newMaxParticipants} onChange={(e) => setNewMaxParticipants(e.target.value === '' ? '' : Number(e.target.value))} />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Category</label>
+                <select value={newCategory} onChange={(e) => setNewCategory(e.target.value as any)} className="p-2 border rounded w-full">
+                  <option value="">--</option>
+                  <option value="mandatory">mandatory</option>
+                  <option value="skill_development">skill_development</option>
+                  <option value="compliance">compliance</option>
+                  <option value="leadership">leadership</option>
+                </select>
+              </div>
+            </div>
+            <label className="text-sm font-medium">Prerequisites</label>
+            <Input value={newPrerequisites} onChange={(e) => setNewPrerequisites(e.target.value)} placeholder="List prerequisites" />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button onClick={handleCreateProgram} disabled={!newTitle}>Create Program</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -756,6 +889,132 @@ export const Training: React.FC = () => {
             <Button variant="outline" onClick={() => setCloseConfirmOpen(false)}>Cancel</Button>
             <Button variant="destructive" onClick={handleConfirmClose}>Close Training</Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* HR View Program Dialog */}
+      <Dialog open={viewDialogOpen} onOpenChange={setViewDialogOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Program Details</DialogTitle>
+            <DialogDescription>Summary of the selected program</DialogDescription>
+          </DialogHeader>
+          {viewProgram && (
+            <div className="space-y-3 text-sm">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div><span className="font-medium">Title:</span> {viewProgram.title}</div>
+                <div><span className="font-medium">Provider:</span> {viewProgram.provider || 'N/A'}</div>
+                <div><span className="font-medium">Type:</span> {viewProgram.type || 'N/A'}</div>
+                <div><span className="font-medium">Category:</span> {(viewProgram.category || '').toString().replace('_',' ') || 'N/A'}</div>
+                <div><span className="font-medium">Duration:</span> {viewProgram.duration ? `${viewProgram.duration} hours` : 'N/A'}</div>
+                <div><span className="font-medium">Max Participants:</span> {viewProgram.maxParticipants ?? 'N/A'}</div>
+                <div><span className="font-medium">Enrolled:</span> {viewProgram.enrolled}</div>
+                <div><span className="font-medium">Completed:</span> {viewProgram.completed}</div>
+                <div><span className="font-medium">Earliest Expiry:</span> {viewProgram.expiryDate ? new Date(viewProgram.expiryDate).toLocaleDateString() : 'N/A'}</div>
+              </div>
+              {viewProgram.prerequisites && (
+                <div>
+                  <span className="font-medium">Prerequisites:</span>
+                  <p className="text-muted-foreground">{viewProgram.prerequisites}</p>
+                </div>
+              )}
+              {viewProgram.description && (
+                <div>
+                  <span className="font-medium">Description:</span>
+                  <p className="text-muted-foreground">{viewProgram.description}</p>
+                </div>
+              )}
+          </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* HR Close All Confirmation */}
+      <Dialog open={closeAllDialogOpen} onOpenChange={setCloseAllDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Close All Assignments</DialogTitle>
+            <DialogDescription>
+              {programToCloseAll ? `This will hide all assignments for "${programToCloseAll.title}" from assignees. You can reopen later.` : ''}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-2 text-sm">
+            {programToCloseAll && (() => {
+              const count = trainings.filter(t => t.title === programToCloseAll.title && !t.archived).length;
+              return <span>{count} assignment{count !== 1 ? 's' : ''} will be closed (hidden).</span>;
+            })()}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCloseAllDialogOpen(false)}>Cancel</Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (!programToCloseAll) return;
+                // Find all assignments for the selected program title
+                const allForProgram = trainings.filter(t => t.title === programToCloseAll.title);
+                // Archive (hide) those not already archived; keep their status so progress is preserved
+                const toArchive = allForProgram.filter(t => !t.archived);
+                toArchive.forEach(r => archiveTraining(r.id));
+                const archivedCount = toArchive.length;
+                // Switch to History so the user immediately sees archived items
+                setActiveTab('history');
+                toast({
+                  title: 'Program closed',
+                  description: `Archived (hidden) ${archivedCount} assignment(s) for ${programToCloseAll.title}.`
+                });
+                setCloseAllDialogOpen(false);
+                setProgramToCloseAll(null);
+              }}
+            >
+              Confirm Close All
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* History View Modal: Per-program archived assignments */}
+      <Dialog open={historyViewOpen} onOpenChange={setHistoryViewOpen}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Archived Assignments: {historyView?.title}</DialogTitle>
+            <DialogDescription>
+              {historyView ? `${historyView.completed}/${historyView.total} completed` : ''}
+            </DialogDescription>
+          </DialogHeader>
+          {historyView && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <p className="text-sm font-semibold mb-2">Completed</p>
+                <div className="space-y-2 max-h-60 overflow-y-auto">
+                  {historyView.items.filter(i => i.status === 'completed').map(i => (
+                    <div key={i.id} className="p-2 border rounded">
+                      <p className="text-sm font-medium">{i.employeeName}</p>
+                      {i.department && <p className="text-xs text-muted-foreground">{i.department}</p>}
+                      {i.completionDate && <p className="text-xs text-muted-foreground">Completed: {new Date(i.completionDate).toLocaleDateString()}</p>}
+                    </div>
+                  ))}
+                  {historyView.items.filter(i => i.status === 'completed').length === 0 && (
+                    <p className="text-xs text-muted-foreground">No completions</p>
+                  )}
+                </div>
+              </div>
+              <div>
+                <p className="text-sm font-semibold mb-2">Not Completed</p>
+                <div className="space-y-2 max-h-60 overflow-y-auto">
+                  {historyView.items.filter(i => i.status !== 'completed').map(i => (
+                    <div key={i.id} className="p-2 border rounded">
+                      <p className="text-sm font-medium">{i.employeeName}</p>
+                      {i.department && <p className="text-xs text-muted-foreground">{i.department}</p>}
+                      <p className="text-xs text-muted-foreground">Status: {i.status.replace('_',' ')}</p>
+                    </div>
+                  ))}
+                  {historyView.items.filter(i => i.status !== 'completed').length === 0 && (
+                    <p className="text-xs text-muted-foreground">Everyone completed</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/src/pages/TrainingAssign.tsx
+++ b/src/pages/TrainingAssign.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useEmployees } from '@/contexts/EmployeesContext';
+import { useTraining } from '@/contexts/TrainingContext';
+import { useToast } from '@/hooks/use-toast';
+
+const PAGE_SIZE = 24;
+
+const TrainingAssign: React.FC = () => {
+  const { title: routeTitle } = useParams<{ title: string }>();
+  const navigate = useNavigate();
+  const { employees } = useEmployees();
+  const { trainings, createTrainingsBatch } = useTraining();
+  const { toast } = useToast();
+
+  const title = decodeURIComponent(routeTitle || '');
+  const [q, setQ] = useState('');
+  const [department, setDepartment] = useState<string>('all');
+  const [station, setStation] = useState<string>('all');
+  const [page, setPage] = useState<number>(1);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [isAssigning, setIsAssigning] = useState(false);
+  const [allFilteredSelected, setAllFilteredSelected] = useState(false);
+
+  // Derive program metadata from any existing row with the same title
+  const programMeta = useMemo(() => {
+    const m = trainings.find(t => t.title === title);
+    return m ? {
+      title: m.title,
+      provider: m.provider,
+      type: m.type,
+      description: m.description,
+      duration: m.duration,
+      expiryDate: m.expiryDate,
+    } : { title };
+  }, [trainings, title]);
+
+  // Already assigned set (non-archived)
+  const assignedSet = useMemo(() => {
+    const s = new Set<string>();
+    trainings.forEach(t => {
+      if (t.title === title && !t.archived) s.add(String(t.employeeId));
+    });
+    return s;
+  }, [trainings, title]);
+
+  // Build filter options
+  const departments = useMemo(() => {
+    const set = new Set<string>();
+    (employees || []).forEach(e => { if (e.department) set.add(String(e.department)); });
+    return Array.from(set).sort();
+  }, [employees]);
+  const stations = useMemo(() => {
+    const set = new Set<string>();
+    (employees || []).forEach(e => { if (e.stationName) set.add(String(e.stationName)); });
+    return Array.from(set).sort();
+  }, [employees]);
+
+  // Filter employees (exclude HR roles as in existing modal)
+  const baseList = useMemo(() => (employees || []).filter(emp => !/hr_(manager|staff)/i.test(String(emp.position || '').toLowerCase())), [employees]);
+
+  const filtered = useMemo(() => {
+    return baseList.filter(e => {
+      if (department !== 'all' && String(e.department) !== department) return false;
+      if (station !== 'all' && String(e.stationName) !== station) return false;
+      if (q) {
+        const hay = `${e.name || ''} ${e.position || ''} ${e.department || ''} ${e.stationName || ''}`.toLowerCase();
+        if (!hay.includes(q.toLowerCase())) return false;
+      }
+      return true;
+    });
+  }, [baseList, department, station, q]);
+
+  // keep all-filtered selection in sync when filters change
+  useEffect(() => {
+    if (allFilteredSelected) {
+      const ids = filtered.map(e => String(e.id)).filter(id => !assignedSet.has(id));
+      setSelected(Array.from(new Set(ids)));
+    }
+  }, [allFilteredSelected, filtered, assignedSet]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  useEffect(() => { setPage(1); }, [department, station, q]);
+  const startIdx = (page - 1) * PAGE_SIZE;
+  const pageRows = filtered.slice(startIdx, startIdx + PAGE_SIZE);
+
+  const toggleSelectAllFiltered = (checked: boolean) => {
+    if (checked) {
+      const ids = pageRows.map(e => String(e.id)).filter(id => !assignedSet.has(id));
+      setSelected(prev => Array.from(new Set([...prev, ...ids])));
+    } else {
+      const ids = new Set(pageRows.map(e => String(e.id)));
+      setSelected(prev => prev.filter(id => !ids.has(id)));
+    }
+  };
+
+  const toggleSelectAllAcrossFiltered = (checked: boolean) => {
+    setAllFilteredSelected(checked);
+    if (checked) {
+      const ids = filtered.map(e => String(e.id)).filter(id => !assignedSet.has(id));
+      setSelected(Array.from(new Set([...selected, ...ids])));
+    } else {
+      // remove all filtered from selection
+      const ids = new Set(filtered.map(e => String(e.id)));
+      setSelected(prev => prev.filter(id => !ids.has(id)));
+    }
+  };
+
+  const assignSelected = async () => {
+    if (!title || selected.length === 0) return;
+    setIsAssigning(true);
+    try {
+      const items = selected
+        .filter(empId => !assignedSet.has(empId))
+        .map(empId => ({
+          employeeId: empId,
+          title: programMeta.title,
+          type: (programMeta as any).type || 'development',
+          provider: (programMeta as any).provider || '',
+          expiryDate: (programMeta as any).expiryDate,
+          status: 'not_started' as const,
+        }));
+      const created = await createTrainingsBatch(items);
+      toast({ title: 'Training assigned', description: `Assigned to ${created.length} employee${created.length === 1 ? '' : 's'}.` });
+      navigate(`/training/program/${encodeURIComponent(title)}`);
+    } finally {
+      setIsAssigning(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Assign Training</h1>
+        <Button variant="outline" onClick={() => navigate(-1)}>Back</Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{programMeta.title}</CardTitle>
+          <CardDescription>Assign this program to employees. Use filters to narrow by department or workstation.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2 items-center">
+          {(programMeta as any).type && <Badge variant={(programMeta as any).type === 'mandatory' ? 'destructive' : 'secondary'}>{(programMeta as any).type}</Badge>}
+          {(programMeta as any).duration && <Badge variant="outline">{(programMeta as any).duration}h</Badge>}
+          {(programMeta as any).provider && <Badge variant="outline">{(programMeta as any).provider}</Badge>}
+          {(programMeta as any).expiryDate && <Badge variant="outline">Expires {(programMeta as any).expiryDate}</Badge>}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-3 items-center">
+          <Input placeholder="Search name, position, dept, station" value={q} onChange={(e) => setQ(e.target.value)} className="max-w-sm" />
+          <Select value={department} onValueChange={(v: string) => setDepartment(v)}>
+            <SelectTrigger className="w-56"><SelectValue placeholder="Department" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Departments</SelectItem>
+              {departments.map(d => <SelectItem key={d} value={d}>{d}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Select value={station} onValueChange={(v: string) => setStation(v)}>
+            <SelectTrigger className="w-56"><SelectValue placeholder="Workstation" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Workstations</SelectItem>
+              {stations.map(s => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Select Employees</CardTitle>
+              <CardDescription>Total {filtered.length} matching • Page {page} of {totalPages}</CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <Checkbox checked={pageRows.every(e => selected.includes(String(e.id)) || assignedSet.has(String(e.id)))} onCheckedChange={(c) => toggleSelectAllFiltered(Boolean(c))} />
+              <span className="text-sm">Select All (this page)</span>
+              <div className="w-px h-5 bg-muted" />
+              <Checkbox checked={allFilteredSelected} onCheckedChange={(c) => toggleSelectAllAcrossFiltered(Boolean(c))} />
+              <span className="text-sm">Select All (filtered)</span>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {/* Selection summary chips */}
+          {selected.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+              <Badge variant="outline">Selected: {selected.length}</Badge>
+              {department !== 'all' && <Badge variant="secondary">Dept: {department}</Badge>}
+              {station !== 'all' && <Badge variant="secondary">Workstation: {station}</Badge>}
+              {q && <Badge variant="outline">Search: "{q}"</Badge>}
+              <Button size="sm" variant="ghost" onClick={() => { setSelected([]); setAllFilteredSelected(false); }}>Clear</Button>
+            </div>
+          )}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+            {pageRows.map(emp => {
+              const id = String(emp.id);
+              const already = assignedSet.has(id);
+              const checked = selected.includes(id) || already;
+              return (
+                <div key={id} className={`flex items-center space-x-3 p-3 border rounded-lg ${already ? 'opacity-60' : ''}`}>
+                  <Checkbox
+                    checked={checked}
+                    disabled={already}
+                    onCheckedChange={(c) => {
+                      if (already) return;
+                      if (c) setSelected(prev => prev.includes(id) ? prev : [...prev, id]);
+                      else setSelected(prev => prev.filter(x => x !== id));
+                    }}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">{emp.name}</p>
+                    <p className="text-xs text-muted-foreground truncate">{emp.position} • {emp.department || emp.stationName}</p>
+                  </div>
+                  {already && <Badge variant="outline">Already assigned</Badge>}
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="flex items-center justify-between mt-3">
+            <div className="text-sm text-muted-foreground">Showing {startIdx + 1}-{Math.min(filtered.length, startIdx + PAGE_SIZE)} of {filtered.length}</div>
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="outline" disabled={page <= 1} onClick={() => setPage(p => Math.max(1, p - 1))}>Prev</Button>
+              <span className="text-sm text-muted-foreground">Page {page} / {totalPages}</span>
+              <Button size="sm" variant="outline" disabled={page >= totalPages} onClick={() => setPage(p => Math.min(totalPages, p + 1))}>Next</Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-blue-600 font-medium">{selected.length} employee{selected.length === 1 ? '' : 's'} selected</div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
+          <Button onClick={assignSelected} disabled={selected.length === 0 || isAssigning}>
+            {isAssigning ? 'Assigning…' : `Assign Training to ${selected.length} Employee${selected.length === 1 ? '' : 's'}`}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TrainingAssign;

--- a/src/pages/TrainingAssign.tsx
+++ b/src/pages/TrainingAssign.tsx
@@ -21,7 +21,6 @@ const TrainingAssign: React.FC = () => {
 
   const title = decodeURIComponent(routeTitle || '');
   const [q, setQ] = useState('');
-  const [department, setDepartment] = useState<string>('all');
   const [station, setStation] = useState<string>('all');
   const [page, setPage] = useState<number>(1);
   const [selected, setSelected] = useState<string[]>([]);
@@ -51,11 +50,6 @@ const TrainingAssign: React.FC = () => {
   }, [trainings, title]);
 
   // Build filter options
-  const departments = useMemo(() => {
-    const set = new Set<string>();
-    (employees || []).forEach(e => { if (e.department) set.add(String(e.department)); });
-    return Array.from(set).sort();
-  }, [employees]);
   const stations = useMemo(() => {
     const set = new Set<string>();
     (employees || []).forEach(e => { if (e.stationName) set.add(String(e.stationName)); });
@@ -67,15 +61,14 @@ const TrainingAssign: React.FC = () => {
 
   const filtered = useMemo(() => {
     return baseList.filter(e => {
-      if (department !== 'all' && String(e.department) !== department) return false;
       if (station !== 'all' && String(e.stationName) !== station) return false;
       if (q) {
-        const hay = `${e.name || ''} ${e.position || ''} ${e.department || ''} ${e.stationName || ''}`.toLowerCase();
+        const hay = `${e.name || ''} ${e.position || ''} ${e.stationName || ''}`.toLowerCase();
         if (!hay.includes(q.toLowerCase())) return false;
       }
       return true;
     });
-  }, [baseList, department, station, q]);
+  }, [baseList, station, q]);
 
   // keep all-filtered selection in sync when filters change
   useEffect(() => {
@@ -86,7 +79,7 @@ const TrainingAssign: React.FC = () => {
   }, [allFilteredSelected, filtered, assignedSet]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
-  useEffect(() => { setPage(1); }, [department, station, q]);
+  useEffect(() => { setPage(1); }, [station, q]);
   const startIdx = (page - 1) * PAGE_SIZE;
   const pageRows = filtered.slice(startIdx, startIdx + PAGE_SIZE);
 
@@ -144,7 +137,7 @@ const TrainingAssign: React.FC = () => {
       <Card>
         <CardHeader>
           <CardTitle>{programMeta.title}</CardTitle>
-          <CardDescription>Assign this program to employees. Use filters to narrow by department or workstation.</CardDescription>
+          <CardDescription>Assign this program to employees. Use filters to narrow by workstation.</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-wrap gap-2 items-center">
           {(programMeta as any).type && <Badge variant={(programMeta as any).type === 'mandatory' ? 'destructive' : 'secondary'}>{(programMeta as any).type}</Badge>}
@@ -159,14 +152,7 @@ const TrainingAssign: React.FC = () => {
           <CardTitle>Filters</CardTitle>
         </CardHeader>
         <CardContent className="flex flex-wrap gap-3 items-center">
-          <Input placeholder="Search name, position, dept, station" value={q} onChange={(e) => setQ(e.target.value)} className="max-w-sm" />
-          <Select value={department} onValueChange={(v: string) => setDepartment(v)}>
-            <SelectTrigger className="w-56"><SelectValue placeholder="Department" /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Departments</SelectItem>
-              {departments.map(d => <SelectItem key={d} value={d}>{d}</SelectItem>)}
-            </SelectContent>
-          </Select>
+          <Input placeholder="Search name, position, workstation" value={q} onChange={(e) => setQ(e.target.value)} className="max-w-sm" />
           <Select value={station} onValueChange={(v: string) => setStation(v)}>
             <SelectTrigger className="w-56"><SelectValue placeholder="Workstation" /></SelectTrigger>
             <SelectContent>
@@ -198,7 +184,6 @@ const TrainingAssign: React.FC = () => {
           {selected.length > 0 && (
             <div className="flex flex-wrap items-center gap-2 mb-3">
               <Badge variant="outline">Selected: {selected.length}</Badge>
-              {department !== 'all' && <Badge variant="secondary">Dept: {department}</Badge>}
               {station !== 'all' && <Badge variant="secondary">Workstation: {station}</Badge>}
               {q && <Badge variant="outline">Search: "{q}"</Badge>}
               <Button size="sm" variant="ghost" onClick={() => { setSelected([]); setAllFilteredSelected(false); }}>Clear</Button>
@@ -222,7 +207,7 @@ const TrainingAssign: React.FC = () => {
                   />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium truncate">{emp.name}</p>
-                    <p className="text-xs text-muted-foreground truncate">{emp.position} • {emp.department || emp.stationName}</p>
+                    <p className="text-xs text-muted-foreground truncate">{emp.position} • {emp.stationName}</p>
                   </div>
                   {already && <Badge variant="outline">Already assigned</Badge>}
                 </div>

--- a/src/pages/TrainingProgramDetails.tsx
+++ b/src/pages/TrainingProgramDetails.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo, useState } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useTraining } from '@/contexts/TrainingContext';
 import { useEmployees } from '@/contexts/EmployeesContext';
-import { Calendar, CheckCircle, Clock, GraduationCap, ArrowLeft, ExternalLink } from 'lucide-react';
+import { CheckCircle, Clock, GraduationCap, ArrowLeft, ExternalLink } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';

--- a/src/pages/TrainingProgramDetails.tsx
+++ b/src/pages/TrainingProgramDetails.tsx
@@ -1,0 +1,301 @@
+import React, { useMemo, useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useTraining } from '@/contexts/TrainingContext';
+import { useEmployees } from '@/contexts/EmployeesContext';
+import { Calendar, CheckCircle, Clock, GraduationCap, ArrowLeft, ExternalLink } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+
+const TrainingProgramDetails: React.FC = () => {
+  const { title: encoded } = useParams();
+  const navigate = useNavigate();
+  const title = decodeURIComponent(encoded || '');
+  const { trainings, getCertificateUrl, editTraining } = useTraining();
+  const { employees } = useEmployees();
+  const { toast } = useToast();
+  const [q, setQ] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'completed' | 'in_progress' | 'not_started' | 'closed'>('all');
+  const [deptFilter, setDeptFilter] = useState<string>('all');
+  const [bulkBusy, setBulkBusy] = useState(false);
+
+  const related = useMemo(() => trainings.filter(t => (t.title || 'Untitled') === title), [trainings, title]);
+  const sample = related.find(r => r.description || r.provider || (r as any).duration || r.expiryDate || r.type || r.category);
+  const counts = useMemo(() => ({
+    total: related.length,
+    completed: related.filter(r => r.status === 'completed').length,
+    in_progress: related.filter(r => r.status === 'in_progress').length,
+    not_started: related.filter(r => r.status === 'not_started').length,
+    closed: related.filter(r => r.status === 'closed').length,
+    archived: related.filter(r => r.archived).length,
+  }), [related]);
+
+  const people = useMemo(() => related.map(r => {
+    const emp = (employees || []).find(e => e.id === r.employeeId);
+    return {
+      id: r.id,
+      employeeId: r.employeeId,
+      name: emp?.name || `Employee ${r.employeeId}`,
+      department: emp?.department || emp?.stationName,
+      status: r.status,
+      completionDate: r.completionDate,
+      expiryDate: r.expiryDate,
+      archived: r.archived,
+      certUrl: getCertificateUrl(r.id),
+      provider: r.provider,
+    };
+  }).sort((a,b) => a.name.localeCompare(b.name)), [related, employees, getCertificateUrl]);
+
+  const departments = useMemo(() => {
+    const s = new Set<string>();
+    people.forEach(p => { if (p.department) s.add(p.department); });
+    return ['all', ...Array.from(s.values()).sort((a,b)=>a.localeCompare(b))];
+  }, [people]);
+
+  const filteredPeople = useMemo(() => {
+    return people.filter(p => {
+      if (q && !p.name.toLowerCase().includes(q.toLowerCase())) return false;
+      if (statusFilter !== 'all' && p.status !== statusFilter) return false;
+      if (deptFilter !== 'all' && p.department !== deptFilter) return false;
+      return true;
+    });
+  }, [people, q, statusFilter, deptFilter]);
+
+  // Bulk action candidates are scoped to the current filtered view for clarity
+  const archiveCandidates = useMemo(() => (
+    filteredPeople.filter(p => p.status === 'completed' && !p.archived).map(p => p.id)
+  ), [filteredPeople]);
+  const restoreCandidates = useMemo(() => (
+    filteredPeople.filter(p => p.archived).map(p => p.id)
+  ), [filteredPeople]);
+
+  const csvExport = () => {
+    const header = ['Name','Department','Status','Completion Date','Expiry Date'];
+    const rows = filteredPeople.map(p => [
+      p.name,
+      p.department || '',
+      p.status,
+      p.completionDate ? new Date(p.completionDate).toLocaleDateString() : '',
+      p.expiryDate ? new Date(p.expiryDate).toLocaleDateString() : ''
+    ]);
+    const data = [header, ...rows].map(r => r.map(v => `"${String(v).replace(/"/g,'""')}"`).join(',')).join('\n');
+    const blob = new Blob([data], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${title}-assignments.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const restoreAllArchived = async () => {
+    if (restoreCandidates.length === 0) return;
+    const ok = window.confirm(`Reopen ${restoreCandidates.length} archived assignment(s) in the current view?`);
+    if (!ok) return;
+    setBulkBusy(true);
+    try {
+      // For any previously closed records, set status back to not_started so they reappear in Assignments/UI flows
+      const affected = people.filter(p => restoreCandidates.includes(p.id));
+      await Promise.all(affected.map(p => editTraining(p.id, { archived: false, ...(p.status === 'closed' ? { status: 'not_started' as any } : {}) })));
+      toast({ title: 'Reopened', description: `Reopened ${restoreCandidates.length} assignment(s).` });
+    } catch (err) {
+      console.error(err);
+      toast({ title: 'Reopen failed', description: 'Could not reopen some assignments. Please retry.', variant: 'destructive' as any });
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+
+  const archiveAllCompleted = async () => {
+    if (archiveCandidates.length === 0) return;
+    const ok = window.confirm(`Archive ${archiveCandidates.length} completed assignment(s) in the current view?`);
+    if (!ok) return;
+    setBulkBusy(true);
+    try {
+      await Promise.all(archiveCandidates.map(id => editTraining(id, { archived: true })));
+      toast({ title: 'Archived', description: `Archived ${archiveCandidates.length} completed assignment(s).` });
+    } catch (err) {
+      console.error(err);
+      toast({ title: 'Archive failed', description: 'Could not archive some assignments. Please retry.', variant: 'destructive' as any });
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Button variant="outline" size="sm" onClick={() => navigate('/training')}>
+            <ArrowLeft className="w-4 h-4 mr-2" /> Back
+          </Button>
+          <h1 className="text-2xl font-bold">{title}</h1>
+          {sample?.type && <Badge variant={sample.type === 'mandatory' ? 'destructive' : 'secondary'}>{sample.type}</Badge>}
+          {sample?.category && <Badge variant="outline">{String(sample.category).replace('_',' ')}</Badge>}
+        </div>
+        <div className="text-right">
+          {sample?.provider && <div className="text-sm text-muted-foreground">Provider: {sample.provider}</div>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardContent className="p-4 flex items-center gap-3">
+            <div className="bg-success/10 p-2 rounded"><CheckCircle className="w-5 h-5 text-success" /></div>
+            <div><p className="text-sm text-muted-foreground">Completed</p><p className="text-xl font-bold">{counts.completed}</p></div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 flex items-center gap-3">
+            <div className="bg-warning/10 p-2 rounded"><Clock className="w-5 h-5 text-warning" /></div>
+            <div><p className="text-sm text-muted-foreground">In Progress</p><p className="text-xl font-bold">{counts.in_progress}</p></div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 flex items-center gap-3">
+            <div className="bg-muted/50 p-2 rounded"><GraduationCap className="w-5 h-5 text-muted-foreground" /></div>
+            <div><p className="text-sm text-muted-foreground">Not Started</p><p className="text-xl font-bold">{counts.not_started}</p></div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Controls */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Filters & Actions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-center gap-3">
+            <Input placeholder="Search by name" value={q} onChange={(e)=>setQ(e.target.value)} className="max-w-xs" />
+            <Select value={statusFilter} onValueChange={(v:any)=>setStatusFilter(v)}>
+              <SelectTrigger className="w-48"><SelectValue placeholder="Status" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All statuses</SelectItem>
+                <SelectItem value="completed">Completed</SelectItem>
+                <SelectItem value="in_progress">In progress</SelectItem>
+                <SelectItem value="not_started">Not started</SelectItem>
+                <SelectItem value="closed">Closed</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={deptFilter} onValueChange={(v:any)=>setDeptFilter(v)}>
+              <SelectTrigger className="w-56"><SelectValue placeholder="Department" /></SelectTrigger>
+              <SelectContent>
+                {departments.map(d => (<SelectItem key={d} value={d}>{d === 'all' ? 'All departments' : d}</SelectItem>))}
+              </SelectContent>
+            </Select>
+            <div className="ml-auto flex items-center gap-2">
+              <Button onClick={() => navigate(`/training/assign/${encodeURIComponent(title)}`)}>Assign</Button>
+              <Button variant="outline" onClick={csvExport} disabled={bulkBusy}>Export CSV</Button>
+              <Button
+                variant="secondary"
+                onClick={restoreAllArchived}
+                disabled={bulkBusy || restoreCandidates.length === 0}
+                title="Applies to the current filtered list"
+              >
+                {`Reopen (${restoreCandidates.length})`}
+              </Button>
+              <Button
+                onClick={archiveAllCompleted}
+                disabled={bulkBusy || archiveCandidates.length === 0}
+                title="Applies to the current filtered list"
+              >
+                {`Close Completed (${archiveCandidates.length})`}
+              </Button>
+            </div>
+            <div className="w-full text-right text-xs text-muted-foreground mt-1">
+              Bulk actions apply to the current filters.
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Department heatmap */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Per-Department Completion</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {(() => {
+            const byDept: Record<string, { total: number; completed: number }> = {};
+            related.forEach(r => {
+              const dept = (employees || []).find(e=>e.id===r.employeeId)?.department || 'Unknown';
+              if (!byDept[dept]) byDept[dept] = { total: 0, completed: 0 };
+              byDept[dept].total += 1;
+              if (r.status === 'completed') byDept[dept].completed += 1;
+            });
+            const entries = Object.entries(byDept).sort((a,b)=>a[0].localeCompare(b[0]));
+            if (entries.length === 0) return <p className="text-sm text-muted-foreground">No data</p>;
+            return entries.map(([dept, v]) => {
+              const pct = v.total ? Math.round((v.completed / v.total) * 100) : 0;
+              return (
+                <div key={dept} className="space-y-1">
+                  <div className="flex justify-between text-sm"><span className="font-medium">{dept}</span><span className="text-muted-foreground">{v.completed}/{v.total} ({pct}%)</span></div>
+                  <div className="h-2 bg-muted rounded"><div className="h-2 rounded" style={{ width: `${pct}%`, backgroundColor: pct >= 80 ? '#16a34a' : pct >= 50 ? '#eab308' : '#ef4444' }} /></div>
+                </div>
+              );
+            });
+          })()}
+        </CardContent>
+      </Card>
+
+      {/* Assignments breakdown */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Assignments</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <p className="text-sm font-semibold mb-2">Completed ({filteredPeople.filter(p=>p.status==='completed').length})</p>
+              <div className="space-y-2 max-h-72 overflow-y-auto">
+                {filteredPeople.filter(p => p.status === 'completed').map(p => (
+                  <div key={p.id} className="p-3 border rounded">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm font-medium">{p.name}</p>
+                        {p.department && <p className="text-xs text-muted-foreground">{p.department}</p>}
+                        {p.completionDate && <p className="text-xs text-muted-foreground">Completed: {new Date(p.completionDate).toLocaleDateString()}</p>}
+                      </div>
+                      <div>
+                        {p.certUrl ? (
+                          <a href={p.certUrl} target="_blank" rel="noreferrer" className="text-sm inline-flex items-center gap-1 text-blue-600 hover:underline">
+                            View Certificate <ExternalLink className="w-3 h-3" />
+                          </a>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">No certificate</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+                {filteredPeople.filter(p => p.status === 'completed').length === 0 && <p className="text-xs text-muted-foreground">No completions</p>}
+              </div>
+            </div>
+            <div>
+              <p className="text-sm font-semibold mb-2">Not Completed ({filteredPeople.filter(p=>p.status !== 'completed').length})</p>
+              <div className="space-y-2 max-h-72 overflow-y-auto">
+                {filteredPeople.filter(p => p.status !== 'completed').map(p => (
+                  <div key={p.id} className="p-3 border rounded">
+                    <p className="text-sm font-medium">{p.name}</p>
+                    {p.department && <p className="text-xs text-muted-foreground">{p.department}</p>}
+                    <p className="text-xs text-muted-foreground">Status: {p.status.replace('_',' ')}</p>
+                    {p.expiryDate && <p className="text-xs text-muted-foreground">Expiry: {new Date(p.expiryDate).toLocaleDateString()}</p>}
+                    {p.archived && p.status === 'closed' && (
+                      <p className="text-xs text-muted-foreground">Closed by HR</p>
+                    )}
+                  </div>
+                ))}
+                {filteredPeople.filter(p => p.status !== 'completed').length === 0 && <p className="text-xs text-muted-foreground">Everyone completed</p>}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default TrainingProgramDetails;

--- a/src/pages/TrainingProgramDetails.tsx
+++ b/src/pages/TrainingProgramDetails.tsx
@@ -39,7 +39,7 @@ const TrainingProgramDetails: React.FC = () => {
       id: r.id,
       employeeId: r.employeeId,
       name: emp?.name || `Employee ${r.employeeId}`,
-      department: emp?.department || emp?.stationName,
+      department: emp?.stationName,
       status: r.status,
       completionDate: r.completionDate,
       expiryDate: r.expiryDate,
@@ -221,7 +221,7 @@ const TrainingProgramDetails: React.FC = () => {
           {(() => {
             const byDept: Record<string, { total: number; completed: number }> = {};
             related.forEach(r => {
-              const dept = (employees || []).find(e=>e.id===r.employeeId)?.department || 'Unknown';
+              const dept = (employees || []).find(e=>e.id===r.employeeId)?.stationName || 'Unknown';
               if (!byDept[dept]) byDept[dept] = { total: 0, completed: 0 };
               byDept[dept].total += 1;
               if (r.status === 'completed') byDept[dept].completed += 1;

--- a/src/pages/TrainingProgress.tsx
+++ b/src/pages/TrainingProgress.tsx
@@ -73,7 +73,7 @@ const TrainingProgress: React.FC = () => {
         if (isNaN(d.getTime()) || d.getFullYear() !== y) return;
       }
       const emp = (employees || []).find(e => e.id === t.employeeId);
-      const dept = (emp?.department || emp?.stationName || 'Unknown').toString();
+  const dept = (emp?.stationName || 'Unknown').toString();
       if (!map.has(dept)) map.set(dept, { total: 0, completed: 0 });
       const cur = map.get(dept)!;
       cur.total += 1;

--- a/src/pages/TrainingProgress.tsx
+++ b/src/pages/TrainingProgress.tsx
@@ -1,0 +1,388 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { useTraining } from '@/contexts/TrainingContext';
+import { useEmployees } from '@/contexts/EmployeesContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { Card as UICard } from '@/components/ui/card';
+
+const TrainingProgress: React.FC = () => {
+  const { trainings } = useTraining();
+  const { employees } = useEmployees();
+  const navigate = useNavigate();
+  const [q, setQ] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'open' | 'closed'>('open');
+  const [trendRes, setTrendRes] = useState<'monthly' | 'weekly'>('monthly');
+  const [deptSort, setDeptSort] = useState<'rate_desc' | 'rate_asc' | 'total_desc' | 'total_asc' | 'name_asc'>('rate_desc');
+  const [page, setPage] = useState<number>(1);
+  const [year, setYear] = useState<string>('all');
+  const pageSize = 10; // fixed page size per requirement
+
+  const programsAgg = useMemo(() => {
+    const map = new Map<string, { title: string; total: number; completed: number; open: number; archived: number; rate: number }>();
+    trainings.forEach(t => {
+      const key = t.title || 'Untitled';
+      if (!map.has(key)) map.set(key, { title: key, total: 0, completed: 0, open: 0, archived: 0, rate: 0 });
+      const cur = map.get(key)!;
+      cur.total += 1;
+      if (t.status === 'completed') cur.completed += 1;
+      if (t.archived) cur.archived += 1; else cur.open += 1;
+    });
+    const arr = Array.from(map.values()).map(p => ({ ...p, rate: p.total ? Math.round((p.completed / p.total) * 100) : 0 }));
+    return arr.sort((a,b) => b.total - a.total);
+  }, [trainings]);
+
+  const totals = useMemo(() => ({
+    totalPrograms: programsAgg.length,
+    openPrograms: programsAgg.filter(p => p.archived < p.total).length,
+    closedPrograms: programsAgg.filter(p => p.archived === p.total).length,
+  }), [programsAgg]);
+
+  // programsAgg is defined above
+
+  const filteredPrograms = useMemo(() => {
+    return programsAgg.filter(p => {
+      if (q && !p.title.toLowerCase().includes(q.toLowerCase())) return false;
+      if (statusFilter === 'open' && !(p.archived < p.total)) return false;
+      if (statusFilter === 'closed' && !(p.archived === p.total)) return false;
+      return true;
+    });
+  }, [programsAgg, q, statusFilter]);
+
+  // reset to first page on filter/query/data change
+  useEffect(() => { setPage(1); }, [q, statusFilter, programsAgg.length]);
+
+  const lowCompletionAlerts = useMemo(() => {
+    return programsAgg.filter(p => p.rate < 50).slice(0, 5);
+  }, [programsAgg]);
+
+  // Department breakdown across all programs
+  const deptBreakdown = useMemo(() => {
+    const map = new Map<string, { total: number; completed: number }>();
+    trainings.forEach(t => {
+      // apply year filter if set
+      if (year !== 'all') {
+        const y = Number(year);
+        const dateStr = t.completionDate || t.expiryDate || '';
+        if (!dateStr) return;
+        const d = new Date(dateStr);
+        if (isNaN(d.getTime()) || d.getFullYear() !== y) return;
+      }
+      const emp = (employees || []).find(e => e.id === t.employeeId);
+      const dept = (emp?.department || emp?.stationName || 'Unknown').toString();
+      if (!map.has(dept)) map.set(dept, { total: 0, completed: 0 });
+      const cur = map.get(dept)!;
+      cur.total += 1;
+      if (t.status === 'completed') cur.completed += 1;
+    });
+    const arr = Array.from(map.entries()).map(([dept, v]) => ({ dept, ...v, rate: v.total ? Math.round((v.completed / v.total) * 100) : 0 }));
+    return arr;
+  }, [trainings, employees, year]);
+
+  const sortedDept = useMemo(() => {
+    const arr = [...deptBreakdown];
+    switch (deptSort) {
+      case 'rate_desc':
+        arr.sort((a,b) => b.rate - a.rate || a.dept.localeCompare(b.dept));
+        break;
+      case 'rate_asc':
+        arr.sort((a,b) => a.rate - b.rate || a.dept.localeCompare(b.dept));
+        break;
+      case 'total_desc':
+        arr.sort((a,b) => b.total - a.total || a.dept.localeCompare(b.dept));
+        break;
+      case 'total_asc':
+        arr.sort((a,b) => a.total - b.total || a.dept.localeCompare(b.dept));
+        break;
+      case 'name_asc':
+      default:
+        arr.sort((a,b) => a.dept.localeCompare(b.dept));
+        break;
+    }
+    return arr;
+  }, [deptBreakdown, deptSort]);
+
+  const exportDeptCsv = () => {
+    const header = ['Department','Completed','Total','Rate'];
+    const rows = sortedDept.map(r => [r.dept, String(r.completed), String(r.total), `${r.rate}%`]);
+    const data = [header, ...rows].map(r => r.map(v => `"${String(v).replace(/"/g,'""')}"`).join(',')).join('\n');
+    const blob = new Blob([data], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'department_breakdown.csv'; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  // Time trend of completions per month (last 12 months)
+  type TrendBucket = { key: string; label: string; count: number };
+  type Trend = { buckets: TrendBucket[]; max: number };
+  const timeTrend: Trend = useMemo(() => {
+    if (trendRes === 'monthly') {
+      const now = new Date();
+      const buckets: TrendBucket[] = [];
+      for (let i = 11; i >= 0; i--) {
+        const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+        const key = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}`;
+        const label = d.toLocaleString(undefined, { month: 'short' });
+        buckets.push({ key, label, count: 0 });
+      }
+      const indexByKey = new Map(buckets.map((m, idx) => [m.key, idx] as const));
+      trainings.forEach(t => {
+        if (t.status !== 'completed' || !t.completionDate) return;
+        const d = new Date(t.completionDate);
+        if (isNaN(d.getTime())) return;
+        const key = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}`;
+        const idx = indexByKey.get(key);
+        if (idx !== undefined) buckets[idx].count += 1;
+      });
+      const max = Math.max(1, ...buckets.map(m => m.count));
+      return { buckets, max };
+    } else {
+      // weekly (last 12 weeks, starting Monday)
+      const startOfWeek = (d: Date) => {
+        const x = new Date(d);
+        const day = x.getDay();
+        const diff = (day + 6) % 7; // Monday=0
+        x.setDate(x.getDate() - diff);
+        x.setHours(0,0,0,0);
+        return x;
+      };
+      const now = new Date();
+      const w0 = startOfWeek(now);
+      const buckets: TrendBucket[] = [];
+      const starts: number[] = [];
+      for (let i = 11; i >= 0; i--) {
+        const s = new Date(w0);
+        s.setDate(s.getDate() - i * 7);
+        const key = `${s.getFullYear()}-W${String(Math.ceil(((s.getDate() + ((s.getDay()+6)%7)))/7)).padStart(2,'0')}-${String(s.getMonth()+1).padStart(2,'0')}`; // approximate key
+        const label = `${s.toLocaleString(undefined, { month: 'short' })} ${s.getDate()}`;
+        buckets.push({ key, label, count: 0 });
+        starts.push(s.getTime());
+      }
+      const indexByStart = new Map(starts.map((t, idx) => [t, idx] as const));
+      trainings.forEach(t => {
+        if (t.status !== 'completed' || !t.completionDate) return;
+        const d = new Date(t.completionDate);
+        if (isNaN(d.getTime())) return;
+        const s = startOfWeek(d).getTime();
+        const idx = indexByStart.get(s);
+        if (idx !== undefined) buckets[idx].count += 1;
+      });
+      const max = Math.max(1, ...buckets.map(m => m.count));
+      return { buckets, max };
+    }
+  }, [trainings, trendRes]);
+
+  // Available years for filtering (from completionDate/expiryDate)
+  const availableYears = useMemo(() => {
+    const set = new Set<number>();
+    trainings.forEach(t => {
+      const dates = [t.completionDate, t.expiryDate].filter(Boolean) as string[];
+      dates.forEach(ds => { const d = new Date(ds); if (!isNaN(d.getTime())) set.add(d.getFullYear()); });
+    });
+    return Array.from(set.values()).sort((a,b) => b - a);
+  }, [trainings]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Training Progress</h1>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card><CardContent className="p-4"><p className="text-xs text-muted-foreground">Total Programs</p><p className="text-2xl font-bold">{totals.totalPrograms}</p></CardContent></Card>
+        <Card><CardContent className="p-4"><p className="text-xs text-muted-foreground">Open Programs</p><p className="text-2xl font-bold">{totals.openPrograms}</p></CardContent></Card>
+        <Card><CardContent className="p-4"><p className="text-xs text-muted-foreground">Closed Programs</p><p className="text-2xl font-bold">{totals.closedPrograms}</p></CardContent></Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Programs by Completion</CardTitle>
+          <CardDescription>Click a program to inspect details</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Controls */}
+          <div className="flex flex-wrap items-center gap-3">
+            <Input placeholder="Search program" value={q} onChange={(e)=>setQ(e.target.value)} className="max-w-xs" />
+            <Select value={statusFilter} onValueChange={(v: 'all' | 'open' | 'closed') => setStatusFilter(v)}>
+              <SelectTrigger className="w-44"><SelectValue placeholder="Status" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All statuses</SelectItem>
+                <SelectItem value="open">Open</SelectItem>
+                <SelectItem value="closed">Closed</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Table with pagination (10 rows per page) */}
+          {(() => {
+            const total = filteredPrograms.length;
+            if (total === 0) return <p className="text-sm text-muted-foreground">No programs match your filters.</p>;
+            const totalPages = Math.max(1, Math.ceil(total / pageSize));
+            const safePage = Math.min(page, totalPages);
+            const startIdx = (safePage - 1) * pageSize;
+            const endIdx = Math.min(total, startIdx + pageSize);
+            const rows = filteredPrograms.slice(startIdx, endIdx);
+            return (
+              <>
+                <div className="overflow-x-auto">
+                  <table className="min-w-full table-auto border rounded">
+                    <thead className="bg-muted/50">
+                      <tr className="text-left text-sm">
+                        <th className="p-2">Program</th>
+                        <th className="p-2">Open</th>
+                        <th className="p-2">Archived</th>
+                        <th className="p-2">Completed</th>
+                        <th className="p-2">Rate</th>
+                        <th className="p-2">Status</th>
+                        <th className="p-2 text-right">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map(p => {
+                        const statusBadge = p.archived === p.total
+                          ? <Badge variant="outline" className="bg-gray-100 text-gray-700">Closed</Badge>
+                          : <Badge variant="secondary">Open</Badge>;
+                        return (
+                          <tr key={p.title} className="border-b last:border-0">
+                            <td className="p-2">
+                              <button className="text-left font-medium hover:underline" onClick={() => navigate(`/training/program/${encodeURIComponent(p.title)}`)}>
+                                {p.title}
+                              </button>
+                            </td>
+                            <td className="p-2 text-sm">{p.open}</td>
+                            <td className="p-2 text-sm">{p.archived}</td>
+                            <td className="p-2 text-sm">{p.completed}/{p.total}</td>
+                            <td className="p-2 text-sm">{p.rate}%
+                              <div className="mt-1"><Progress value={p.rate} /></div>
+                            </td>
+                            <td className="p-2">{statusBadge}</td>
+                            <td className="p-2">
+                              <div className="flex justify-end">
+                                <Button size="sm" variant="outline" onClick={() => navigate(`/training/program/${encodeURIComponent(p.title)}`)}>View</Button>
+                              </div>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+                <div className="flex items-center justify-between mt-2 text-sm">
+                  <div className="text-muted-foreground">Showing {startIdx + 1}-{endIdx} of {total}</div>
+                  <div className="flex items-center gap-2">
+                    <Button size="sm" variant="outline" disabled={safePage <= 1} onClick={() => setPage(p => Math.max(1, p - 1))}>Prev</Button>
+                    <span className="text-muted-foreground">Page {safePage} of {totalPages}</span>
+                    <Button size="sm" variant="outline" disabled={safePage >= totalPages} onClick={() => setPage(p => Math.min(totalPages, p + 1))}>Next</Button>
+                  </div>
+                </div>
+              </>
+            );
+          })()}
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Alerts: Low Completion</CardTitle>
+            <CardDescription>Programs under 50% completion</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {lowCompletionAlerts.length === 0 && (
+              <p className="text-sm text-muted-foreground">No alerts</p>
+            )}
+            {lowCompletionAlerts.map(p => (
+              <div key={p.title} className="flex items-center justify-between p-2 border rounded">
+                <button className="text-left font-medium hover:underline" onClick={() => navigate(`/training/program/${encodeURIComponent(p.title)}`)}>{p.title}</button>
+                <span className="text-xs text-muted-foreground">{p.completed}/{p.total} ({p.rate}%)</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <CardTitle>Department Breakdown</CardTitle>
+                <CardDescription>Completion rate by department (all programs)</CardDescription>
+              </div>
+              <div className="flex items-center gap-2">
+                <Select value={deptSort} onValueChange={(v: 'rate_desc' | 'rate_asc' | 'total_desc' | 'total_asc' | 'name_asc') => setDeptSort(v)}>
+                  <SelectTrigger className="w-40"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="rate_desc">Sort: Rate ↓</SelectItem>
+                    <SelectItem value="rate_asc">Sort: Rate ↑</SelectItem>
+                    <SelectItem value="total_desc">Sort: Total ↓</SelectItem>
+                    <SelectItem value="total_asc">Sort: Total ↑</SelectItem>
+                    <SelectItem value="name_asc">Sort: Name A–Z</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button variant="outline" onClick={exportDeptCsv}>Export CSV</Button>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {sortedDept.length === 0 && (
+              <p className="text-sm text-muted-foreground">No department data.</p>
+            )}
+            {sortedDept.map(row => (
+              <div key={row.dept} className="space-y-1">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-medium">{row.dept}</span>
+                  <span className="text-muted-foreground">{row.completed}/{row.total} ({row.rate}%)</span>
+                </div>
+                <div className="h-2 bg-muted rounded" title={`${row.dept}: ${row.completed}/${row.total} (${row.rate}%)`}>
+                  <div className="h-2 rounded" style={{ width: `${row.rate}%`, backgroundColor: row.rate >= 80 ? '#16a34a' : row.rate >= 50 ? '#eab308' : '#ef4444' }} />
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Time Trend</CardTitle>
+          <div className="flex items-center justify-between">
+            <CardDescription>Completions over time</CardDescription>
+            <div className="flex items-center gap-2">
+              <Select value={year} onValueChange={(v: string) => setYear(v)}>
+                  <SelectTrigger className="w-32"><SelectValue placeholder="Year" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Year: All</SelectItem>
+                    {availableYears.map(y => (<SelectItem key={y} value={String(y)}>{y}</SelectItem>))}
+                  </SelectContent>
+                </Select>
+              <Button variant={trendRes === 'monthly' ? 'default' : 'outline'} size="sm" onClick={() => setTrendRes('monthly')}>Monthly</Button>
+              <Button variant={trendRes === 'weekly' ? 'default' : 'outline'} size="sm" onClick={() => setTrendRes('weekly')}>Weekly</Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {timeTrend.buckets.every(m => m.count === 0) ? (
+            <p className="text-sm text-muted-foreground">No completions in the last 12 {trendRes === 'monthly' ? 'months' : 'weeks'}.</p>
+          ) : (
+            <div className="flex items-end gap-2 h-40">
+              {timeTrend.buckets.map((b, idx) => {
+                const h = Math.max(4, Math.round((b.count / timeTrend.max) * 140));
+                return (
+                  <div key={idx} className="flex flex-col items-center gap-1">
+                    <div className="w-6 bg-blue-600 rounded" style={{ height: `${h}px` }} title={`${b.label}: ${b.count}`} />
+                    <span className="text-[10px] text-muted-foreground">{b.label}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default TrainingProgress;

--- a/src/pages/TrainingProgress.tsx
+++ b/src/pages/TrainingProgress.tsx
@@ -8,7 +8,6 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { Card as UICard } from '@/components/ui/card';
 
 const TrainingProgress: React.FC = () => {
   const { trainings } = useTraining();

--- a/src/pages/WorkStations.tsx
+++ b/src/pages/WorkStations.tsx
@@ -94,6 +94,7 @@ const WorkStationsPage: React.FC = () => {
         <div>
           <h1 className="text-3xl font-bold mb-2">Work Stations</h1>
           <p className="text-muted-foreground">Manage work stations and view employee counts</p>
+          <p className="text-xs text-muted-foreground mt-1">Note: In this system, a Department is the same as a Workstation. Creating or renaming a workstation updates the department list everywhere.</p>
         </div>
         <div className="flex gap-2">
           <Button variant="outline" size="sm">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => ({
     port: 8080,
     proxy: {
       '/api': {
-        target: 'http://localhost:5001',
+        target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:5000',
         changeOrigin: true,
         secure: false,
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5001',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
     watch: {
       usePolling: true,
       interval: 300,


### PR DESCRIPTION
- Unified DB source; removed localStorage fallback.
- Admin: full edit; timelines on create; programs aggregated by title.
- HR: Assign moved to full page (/training/assign/:title) with filters, Select All (page/filtered), batch-assign API, toasts.
- Reopen/Close: Close hides (archive); Reopen unhides and resets closed→not_started; returns to Assignments.
- Progress Dashboard: defaults to Open; table (10 rows); search/filter; status; low-completion alerts; department breakdown + time trend with weekly/monthly toggle, year filter, sorting, CSV export; tooltips.
- Program Details: deep drill page with filters/search/export; bulk Close/Reopen; Assign button; Back goes to Trainings.
- UI/UX: removed old Assign modal; removed extra dashboard/back buttons; fixed navigate hook error.
- Standardized Department → Workstation across app (Training, Assign, Progress, Program Details, Reports, Leave, Managers, Performance).

Testing
- CRUD via API: GET/POST/PUT/DELETE working in Docker (backend: 5000).
- Reopen returns programs to Assignments; employees no longer see closed items.